### PR TITLE
Remove redundant 'Getting started'

### DIFF
--- a/_shells/modeling-the-shell.md
+++ b/_shells/modeling-the-shell.md
@@ -6,7 +6,7 @@ comments: true
 order:  4
 ---
 
-By defining how a Shell is modeled in CloudShell, we can control how it’s represented in CloudShell. If you’ve gone through the steps of the Getting Started [Getting Started]({{site.baseurl}}/shells/getting-started.html) tutorial, you may have noticed that with little effort we’ve already managed to model a new type of entity.
+By defining how a Shell is modeled in CloudShell, we can control how it’s represented in CloudShell. If you’ve gone through the steps of the [Getting Started]({{site.baseurl}}/shells/getting-started.html) tutorial, you may have noticed that with little effort we’ve already managed to model a new type of entity.
 
 
 In this section, we’ll take a more in-depth look at how we can customize how Shell resources or deployed Apps are presented and behave in CloudShell.


### PR DESCRIPTION
Getting started was written twice...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/devguide_source/64)
<!-- Reviewable:end -->
