### PR TITLE
Customizing Shell Commands - retitle, updated and moved from Shells t…

### DIFF
--- a/_introduction/7.1.0/the-cloudshell-devguide.md
+++ b/_introduction/7.1.0/the-cloudshell-devguide.md
@@ -15,7 +15,7 @@ Welcome to the CloudShell developer guide!
 These pages will take you through all you need to know to become an expert CloudShell developer.
 The guide is intended both for developers taking their first steps with the platform as well as for seasoned CloudShell developers.
 
-_**Before developing shells and scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing shells and scripts, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### How this guide is organized
 

--- a/_introduction/8.0.0/the-cloudshell-devguide.md
+++ b/_introduction/8.0.0/the-cloudshell-devguide.md
@@ -14,7 +14,7 @@ version:
 
 Welcome! In the following pages you will learn all you need to know to become an expert CloudShell developer. The guide is intended both for developers taking their first steps with the platform and seasoned CloudShell developers.
 
-_**Before developing shells and scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing shells and scripts, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### How this guide is organized
 

--- a/_introduction/8.1.0/the-cloudshell-devguide.md
+++ b/_introduction/8.1.0/the-cloudshell-devguide.md
@@ -14,7 +14,7 @@ version:
 
 Welcome! In the following pages you will learn all you need to know to become an expert CloudShell developer. The guide is intended both for developers taking their first steps with the platform and seasoned CloudShell developers.
 
-_**Before developing shells and scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing shells and scripts, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### How this guide is organized
 

--- a/_introduction/8.2.0/the-cloudshell-devguide.md
+++ b/_introduction/8.2.0/the-cloudshell-devguide.md
@@ -14,7 +14,7 @@ version:
 
 Welcome! In the following pages you will learn all you need to know to become an expert CloudShell developer. The guide is intended both for developers taking their first steps with the platform and seasoned CloudShell developers.
 
-_**Before developing shells and scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing shells and scripts, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### How this guide is organized
 

--- a/_orchestration/7.1.0/getting-started.md
+++ b/_orchestration/7.1.0/getting-started.md
@@ -13,7 +13,7 @@ Orchestration scripts can enable automating sandbox workflows. You can use orche
 and teardown procedures as well as other custom workflows that can be made available in the sandbox. Examples would include
 saving and restoring state, starting test traffic, running a failover scenarios and more.
 
-_**Before developing scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing scripts, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### Creating a simple environment script
 

--- a/_orchestration/8.0.0/getting-started.md
+++ b/_orchestration/8.0.0/getting-started.md
@@ -17,7 +17,7 @@ Orchestration scripts can enable automating sandbox workflows. You can use orche
 and teardown procedures as well as other custom workflows that can be made available in the sandbox. Examples would include
 saving and restoring state, starting test traffic, running a failover scenarios and more.
 
-_**Before developing scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing scripts, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### Creating and using orchestration scripts in CloudShell
 

--- a/_orchestration/8.0.0/getting-started.md
+++ b/_orchestration/8.0.0/getting-started.md
@@ -25,7 +25,7 @@ This procedure shows the basic steps for creating and using orchestration script
 
 1) Create a python script. You can create a single python script, or a more complex orchestration that uses dependencies, as explained in [Scripts Deep Dive]({{site.baseurl}}/orchestration/{{pageVersion}}/scripts-deep-dive.html).
 
-2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See the online help's [Updating Python Dependencies for Shells and Drivers](http://help.quali.com/Online%20Help/8.0.0.7741/Portal/Content/Admn/Updt-Python-Libs.htm).
+2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See CloudShell Help's [Updating Python Dependencies for Shells and Drivers](http://help.quali.com/Online%20Help/8.0.0.7741/Portal/Content/Admn/Updt-Python-Libs.htm).
 
 3) Upload the script to CloudShell. When uploading the script, you can set it as a setup or teardown script, to have it run automatically in the sandbox, or leave it as a manually launched orchestration script.
 

--- a/_orchestration/8.0.0/getting-started.md
+++ b/_orchestration/8.0.0/getting-started.md
@@ -8,13 +8,28 @@ version:
     - 8.0.0
 tags:
     - orchestration
- 
 ---
+
+{% assign pageUrlSplited = page.url | split: "/" %}
+{% assign pageVersion = pageUrlSplited[2] %}
+
 Orchestration scripts can enable automating sandbox workflows. You can use orchestration scripts to create setup
 and teardown procedures as well as other custom workflows that can be made available in the sandbox. Examples would include
 saving and restoring state, starting test traffic, running a failover scenarios and more.
 
 _**Before developing scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+
+### Creating and using orchestration scripts in CloudShell
+
+This procedure shows the basic steps for creating and using orchestration scripts in CloudShell.
+
+1) Create a python script. You can create a single python script, or a more complex orchestration that uses dependencies, as explained in [Scripts Deep Dive]({{site.baseurl}}/orchestration/{{pageVersion}}/scripts-deep-dive.html).
+
+2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See the online help's [Updating Python Dependencies for Shells and Drivers](http://help.quali.com/Online%20Help/8.0.0.7741/Portal/Content/Admn/Updt-Python-Libs.htm).
+
+3) Upload the script to CloudShell. When uploading the script, you can set it as a setup or teardown script, to have it run automatically in the sandbox, or leave it as a manually launched orchestration script.
+
+4) Attach the script to the blueprint. If it’s a setup or teardown script, remove the blueprint’s existing script first.
 
 ### Creating a simple environment script
 

--- a/_orchestration/8.1.0/getting-started.md
+++ b/_orchestration/8.1.0/getting-started.md
@@ -8,13 +8,28 @@ version:
     - 8.1.0
 tags:
     - orchestration
- 
 ---
+
+{% assign pageUrlSplited = page.url | split: "/" %}
+{% assign pageVersion = pageUrlSplited[2] %}
+
 Orchestration scripts can enable automating sandbox workflows. You can use orchestration scripts to create setup
 and teardown procedures as well as other custom workflows that can be made available in the sandbox. Examples would include
 saving and restoring state, starting test traffic, running a failover scenarios and more.
 
 _**Before developing scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+
+### Creating and using orchestration scripts in CloudShell
+
+This procedure shows the basic steps for creating and using orchestration scripts in CloudShell.
+
+1) Create a python script. You can create a single python script, or a more complex orchestration that uses dependencies, as explained in [Scripts Deep Dive]({{site.baseurl}}/orchestration/{{pageVersion}}/scripts-deep-dive.html).
+
+2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See the online help's [Updating Python Dependencies for Shells, Drivers and Scripts](http://help.quali.com/Online%20Help/8.1.0.4496/Portal/Content/Admn/Updt-Pyth-Libs.htm).
+
+3) Upload the script to CloudShell. When uploading the script, you can set it as a setup or teardown script, to have it run automatically in the sandbox, or leave it as a manually launched orchestration script.
+
+4) Attach the script to the blueprint. If it’s a setup or teardown script, remove the blueprint’s existing script first.
 
 ### Creating a simple environment script
 

--- a/_orchestration/8.1.0/getting-started.md
+++ b/_orchestration/8.1.0/getting-started.md
@@ -17,7 +17,7 @@ Orchestration scripts can enable automating sandbox workflows. You can use orche
 and teardown procedures as well as other custom workflows that can be made available in the sandbox. Examples would include
 saving and restoring state, starting test traffic, running a failover scenarios and more.
 
-_**Before developing scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing scripts, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### Creating and using orchestration scripts in CloudShell
 

--- a/_orchestration/8.1.0/getting-started.md
+++ b/_orchestration/8.1.0/getting-started.md
@@ -25,7 +25,7 @@ This procedure shows the basic steps for creating and using orchestration script
 
 1) Create a python script. You can create a single python script, or a more complex orchestration that uses dependencies, as explained in [Scripts Deep Dive]({{site.baseurl}}/orchestration/{{pageVersion}}/scripts-deep-dive.html).
 
-2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See the online help's [Updating Python Dependencies for Shells, Drivers and Scripts](http://help.quali.com/Online%20Help/8.1.0.4496/Portal/Content/Admn/Updt-Pyth-Libs.htm).
+2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See CloudShell Help's [Updating Python Dependencies for Shells, Drivers and Scripts](http://help.quali.com/Online%20Help/8.1.0.4496/Portal/Content/Admn/Updt-Pyth-Libs.htm).
 
 3) Upload the script to CloudShell. When uploading the script, you can set it as a setup or teardown script, to have it run automatically in the sandbox, or leave it as a manually launched orchestration script.
 

--- a/_orchestration/8.2.0/getting-started.md
+++ b/_orchestration/8.2.0/getting-started.md
@@ -25,7 +25,7 @@ This procedure shows the basic steps for creating and using orchestration script
 
 1) Create a python script. You can create a single python script, or a more complex orchestration that uses dependencies, as explained in [Scripts Deep Dive]({{site.baseurl}}/orchestration/{{pageVersion}}/scripts-deep-dive.html).
 
-2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See the online help's [Updating Python Dependencies for Shells, Drivers and Scripts](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Updt-Pyth-Libs.htm).
+2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See CloudShell Help's [Updating Python Dependencies for Shells, Drivers and Scripts](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Updt-Pyth-Libs.htm).
 
 3) Upload the script to CloudShell. When uploading the script, you can set it as a setup or teardown script, to have it run automatically in the sandbox, or leave it as a manually launched orchestration script.
 

--- a/_orchestration/8.2.0/getting-started.md
+++ b/_orchestration/8.2.0/getting-started.md
@@ -8,13 +8,28 @@ version:
     - 8.2.0
 tags:
     - orchestration
- 
 ---
+
+{% assign pageUrlSplited = page.url | split: "/" %}
+{% assign pageVersion = pageUrlSplited[2] %}
+
 Orchestration scripts can enable automating sandbox workflows. You can use orchestration scripts to create setup
 and teardown procedures as well as other custom workflows that can be made available in the sandbox. Examples would include
 saving and restoring state, starting test traffic, running a failover scenarios and more.
 
 _**Before developing scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+
+### Creating and using orchestration scripts in CloudShell
+
+This procedure shows the basic steps for creating and using orchestration scripts in CloudShell.
+
+1) Create a python script. You can create a single python script, or a more complex orchestration that uses dependencies, as explained in [Scripts Deep Dive]({{site.baseurl}}/orchestration/{{pageVersion}}/scripts-deep-dive.html).
+
+2) If the script requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See the online help's [Updating Python Dependencies for Shells, Drivers and Scripts](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Updt-Pyth-Libs.htm).
+
+3) Upload the script to CloudShell. When uploading the script, you can set it as a setup or teardown script, to have it run automatically in the sandbox, or leave it as a manually launched orchestration script.
+
+4) Attach the script to the blueprint. If it’s a setup or teardown script, remove the blueprint’s existing script first.
 
 ### Creating a simple environment script
 

--- a/_orchestration/8.2.0/getting-started.md
+++ b/_orchestration/8.2.0/getting-started.md
@@ -17,7 +17,7 @@ Orchestration scripts can enable automating sandbox workflows. You can use orche
 and teardown procedures as well as other custom workflows that can be made available in the sandbox. Examples would include
 saving and restoring state, starting test traffic, running a failover scenarios and more.
 
-_**Before developing scripts, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing scripts, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### Creating and using orchestration scripts in CloudShell
 

--- a/_reference/8.0.0/associating-service-categories.md
+++ b/_reference/8.0.0/associating-service-categories.md
@@ -2,7 +2,7 @@
 layout: page
 title: Associating Categories to 1st Gen Service Shells
 category: ref
-order: 10
+order: 11
 comments: true
 version:
     - 8.0.0

--- a/_reference/8.0.0/migrating_1st_gen_shells.md
+++ b/_reference/8.0.0/migrating_1st_gen_shells.md
@@ -2,7 +2,7 @@
 layout: page
 title: Converting 1st Gen Shells into 2nd Gen Shells
 category: ref
-order: 9
+order: 10
 comments: true
 version:
     - 8.0.0

--- a/_reference/8.0.0/quali-shell-framework.md
+++ b/_reference/8.0.0/quali-shell-framework.md
@@ -132,7 +132,7 @@ Overall, we have six Runners, all base classes and their interfaces are located 
 
 * **[Run Command Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/run_command_runner.py)** – As you can see from the name, this Runner handles the `Run Custom Command` and `Run Custom Config Command` driver methods, and doesn’t require anything to implement besides the *cli_handler*. However, if you want to customize the `run_command_flow` property, you are welcome to override it. To initialize this runner, just pass the logger object.
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_run_command_runner.py).
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_configuration_runner.py).
 
 * **[State Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/state_runner.py)** – This runner is very similar to the Run Custom Command Runner as it only requires the *cli_handler* object to be implemented. It contains implementations for the `Health Check` and `Shutdown` commands. To initialize this runner, you need to pass the `logger`, `api` and `resource_config` objects mentioned in [Key Entities](#KeyEntities).
 

--- a/_reference/8.0.0/quali-shell-framework.md
+++ b/_reference/8.0.0/quali-shell-framework.md
@@ -136,8 +136,6 @@ Overall, we have six Runners, all base classes and their interfaces are located 
 
 * **[State Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/state_runner.py)** – This runner is very similar to the Run Custom Command Runner as it only requires the *cli_handler* object to be implemented. It contains implementations for the `Health Check` and `Shutdown` commands. To initialize this runner, you need to pass the `logger`, `api` and `resource_config` objects mentioned in [Key Entities](#KeyEntities).
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_state_runner.py).
-
 * **[Autoload Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/autoload_runner.py)** – discovers the device’s hardware structure and general details, such as the firmware version and model. This is the only runner that doesn’t require the *cli_handler* object, but requires the following properties to be implemented:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• snmp_handler

--- a/_reference/8.0.0/quali-shell-framework.md
+++ b/_reference/8.0.0/quali-shell-framework.md
@@ -1,32 +1,32 @@
 ---
 layout: page
-title: Customizing a Shell's Commands
-category: tut
-order: 18
+title: Quali’s Shell Framework
+category: ref
+order: 9
 comments: true
 version:
-    - 8.1.0
+    - 8.0.0
 ---
+
 
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this article, we will familiarize ourselves with the architecture of the shell's automation piece and learn how to develop and customize commands using the shell infrastructure. Note that this applies to 1st Gen and 2nd Gen shells.
+In this article, we will familiarize ourselves with the CloudShell Shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen Shells.
 
 ## Introduction
 
-CloudShell shells consist of a data model and a driver. The driver is written in python and can have python package dependencies. Quali’s officially released shells use a common set of python packages developed by Quali, which contain most of the logic of Quali shells, while the driver itself (the “.py” file inside the shell) is the thin layer which defines the interface with CloudShell along with the driver python requirements.
-
-Quali’s official shells have a granularity level of Vendor and OS, meaning that a shell supports all devices of a specific vendor and OS, and the exact functionality the shell exposes is defined in the relevant shell standard. The structure of the python packages reflects this granularity; for example, any logic which is common to all networking devices will reside in cloudshell-networking, any Cisco-specific logic will reside in cloudshell-networking-cisco and any Cisco IOS-specific logic will reside in cloudshell-networking-cisco-ios.
-
-When creating your own shell from scratch, or when extending an official Quali shell by adding/modifying commands, it is recommended to leverage Quali’s shell infrastructure and python packages. Adding new commands or customizing existing ones should be done in the python driver that resides in the shell itself. You can write your code directly there or you can place it in a separate python package that you’ll add as a requirement to the driver. Such custom python packages can be loaded into our local [PyPi server](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Cnfgr-Pyth-Env-Wrk-Offln.htm?Highlight=pypi) and thus be available to your entire CloudShell deployment.
+Every CloudShell shell consists of a data model and a driver. The driver is written in python and can have python package dependencies. Quali’s officially released shells use a common set of python packages developed by Quali, which contain most of the logic of Quali shells, while the driver itself (the “.py” file inside the shell) is the thin layer that defines the interface with CloudShell along with the driver’s python requirements.
+Quali’s official shells have a granularity level of Vendor and OS. This means that each official shell supports all devices of a specific vendor and OS. The exact functionality that is exposed by the shell is defined in the relevant shell standard. The structure of the python packages reflects this granularity – for example, any logic that is common to all networking devices resides in cloudshell-networking, while any Cisco-specific logic resides in cloudshell-networking-cisco, and any Cisco IOS-specific logic resides in cloudshell-networking-cisco-ios.
+It is possible to use Quali’s shell framework when creating your own shells or customizing existing ones. Note that using the framework is optional.
+To work with one or more of the framework’s python packages, you need to list it in your shell project’s requirements, and not fork it or directly edit it. Then you can either write the code, which uses the package, directly in the shell’s driver or create your own python package and add it to the requirements of the driver. Such custom python packages can be loaded into our [PyPi server](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Cnfgr-Pyth-Env-Wrk-Offln.htm?Highlight=pypi) and thus be available to your entire CloudShell deployment.
 
 **Important:** It is not recommended to modify Quali python packages as these changes may be overwritten if a newer package that has the same file name is published on the public PyPi repository. Alternatively, you’re welcome to create your own packages, using our python packages as a reference.
 
 
 ## Python package structure
 
-The following diagram shows the python classes used by the shell commands and their dependencies.
+The following diagram shows the python classes used by the shell commands and their dependencies:
 
 ![Python Package Structure Diagram]({{ site.baseurl}}/assets/python-package-structure.png)
 
@@ -44,7 +44,7 @@ An additional element that is used by the runners is the communication handler, 
  
 ## Key Entities<a name="KeyEntities"></a>
 
-There are several objects that should be initialized in the python driver, to allow you to work with Quali's infrastructure:
+There are several objects that must be initialized in the python driver, to allow you to work with Quali's infrastructure:
 * **cli** - A Python package that provides an easy abstraction interface for CLI access and communication (Telnet, TCP, SSH etc.) for network devices. The CLI class instance is provided by `cloudshell.cli.cli`. It must be created when the driver is initializing, since it allows the shell to designate a single session pool for all of the shell’s commands. You are welcome to use the *_get_cli* helper from *driver_helper* mentioned above. *_get_cli* allows you to define the session pool’s size and idle timeout. 
 * **api** is an instance of the *cloudshell-automation-API*’s *CloudShellAPISession* class. It must be created on every command execution. This class has a helper named *_get_api*, which is also provided by the *driver_helper* mentioned above.
 * **logger** is a logger object from *cloudshell-core*. It is recommended to use the *driver_helper’s get_logger_with_thread_id* function.

--- a/_reference/8.0.0/quali-shell-framework.md
+++ b/_reference/8.0.0/quali-shell-framework.md
@@ -12,7 +12,7 @@ version:
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this article, we will familiarize ourselves with the CloudShell Shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen Shells.
+In this article, we will familiarize ourselves with the CloudShell shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen shells.
 
 ## Introduction
 
@@ -201,4 +201,3 @@ We need to (1) pass the `session` object, command template and action/error maps
 {% highlight bash %}
 CommandTemplateExecutor(session, CONFIGURE_VLAN, action_map=action_map, error_map=error_map).execute_command(vlan_id=vlan_id)
 {% endhighlight %}
-

--- a/_reference/8.1.0/associating-service-categories.md
+++ b/_reference/8.1.0/associating-service-categories.md
@@ -2,7 +2,7 @@
 layout: page
 title: Associating Categories to 1st Gen Service Shells
 category: ref
-order: 10
+order: 11
 comments: true
 version:
     - 8.1.0

--- a/_reference/8.1.0/migrating_1st_gen_shells.md
+++ b/_reference/8.1.0/migrating_1st_gen_shells.md
@@ -2,7 +2,7 @@
 layout: page
 title: Converting 1st Gen Shells into 2nd Gen Shells
 category: ref
-order: 9
+order: 10
 comments: true
 version:
     - 8.1.0

--- a/_reference/8.1.0/quali-shell-framework.md
+++ b/_reference/8.1.0/quali-shell-framework.md
@@ -1,32 +1,32 @@
 ---
 layout: page
-title: Customizing a Shell's Commands
-category: tut
-order: 18
+title: Quali’s Shell Framework
+category: ref
+order: 9
 comments: true
 version:
-    - 8.2.0
+    - 8.1.0
 ---
+
 
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this article, we will familiarize ourselves with the architecture of the shell's automation piece and learn how to develop and customize commands using the shell infrastructure. Note that this applies to 1st Gen and 2nd Gen shells.
+In this article, we will familiarize ourselves with the CloudShell Shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen Shells.
 
 ## Introduction
 
-CloudShell shells consist of a data model and a driver. The driver is written in python and can have python package dependencies. Quali’s officially released shells use a common set of python packages developed by Quali, which contain most of the logic of Quali shells, while the driver itself (the “.py” file inside the shell) is the thin layer which defines the interface with CloudShell along with the driver python requirements.
-
-Quali’s official shells have a granularity level of Vendor and OS, meaning that a shell supports all devices of a specific vendor and OS, and the exact functionality the shell exposes is defined in the relevant shell standard. The structure of the python packages reflects this granularity; for example, any logic which is common to all networking devices will reside in cloudshell-networking, any Cisco-specific logic will reside in cloudshell-networking-cisco and any Cisco IOS-specific logic will reside in cloudshell-networking-cisco-ios.
-
-When creating your own shell from scratch, or when extending an official Quali shell by adding/modifying commands, it is recommended to leverage Quali’s shell infrastructure and python packages. Adding new commands or customizing existing ones should be done in the python driver that resides in the shell itself. You can write your code directly there or you can place it in a separate python package that you’ll add as a requirement to the driver. Such custom python packages can be loaded into our local [PyPi server](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Cnfgr-Pyth-Env-Wrk-Offln.htm?Highlight=pypi) and thus be available to your entire CloudShell deployment.
+Every CloudShell shell consists of a data model and a driver. The driver is written in python and can have python package dependencies. Quali’s officially released shells use a common set of python packages developed by Quali, which contain most of the logic of Quali shells, while the driver itself (the “.py” file inside the shell) is the thin layer that defines the interface with CloudShell along with the driver’s python requirements.
+Quali’s official shells have a granularity level of Vendor and OS. This means that each official shell supports all devices of a specific vendor and OS. The exact functionality that is exposed by the shell is defined in the relevant shell standard. The structure of the python packages reflects this granularity – for example, any logic that is common to all networking devices resides in cloudshell-networking, while any Cisco-specific logic resides in cloudshell-networking-cisco, and any Cisco IOS-specific logic resides in cloudshell-networking-cisco-ios.
+It is possible to use Quali’s shell framework when creating your own shells or customizing existing ones. Note that using the framework is optional.
+To work with one or more of the framework’s python packages, you need to list it in your shell project’s requirements, and not fork it or directly edit it. Then you can either write the code, which uses the package, directly in the shell’s driver or create your own python package and add it to the requirements of the driver. Such custom python packages can be loaded into our [PyPi server](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Cnfgr-Pyth-Env-Wrk-Offln.htm?Highlight=pypi) and thus be available to your entire CloudShell deployment.
 
 **Important:** It is not recommended to modify Quali python packages as these changes may be overwritten if a newer package that has the same file name is published on the public PyPi repository. Alternatively, you’re welcome to create your own packages, using our python packages as a reference.
 
 
 ## Python package structure
 
-The following diagram shows the python classes used by the shell commands and their dependencies.
+The following diagram shows the python classes used by the shell commands and their dependencies:
 
 ![Python Package Structure Diagram]({{ site.baseurl}}/assets/python-package-structure.png)
 
@@ -44,7 +44,7 @@ An additional element that is used by the runners is the communication handler, 
  
 ## Key Entities<a name="KeyEntities"></a>
 
-There are several objects that should be initialized in the python driver, to allow you to work with Quali's infrastructure:
+There are several objects that must be initialized in the python driver, to allow you to work with Quali's infrastructure:
 * **cli** - A Python package that provides an easy abstraction interface for CLI access and communication (Telnet, TCP, SSH etc.) for network devices. The CLI class instance is provided by `cloudshell.cli.cli`. It must be created when the driver is initializing, since it allows the shell to designate a single session pool for all of the shell’s commands. You are welcome to use the *_get_cli* helper from *driver_helper* mentioned above. *_get_cli* allows you to define the session pool’s size and idle timeout. 
 * **api** is an instance of the *cloudshell-automation-API*’s *CloudShellAPISession* class. It must be created on every command execution. This class has a helper named *_get_api*, which is also provided by the *driver_helper* mentioned above.
 * **logger** is a logger object from *cloudshell-core*. It is recommended to use the *driver_helper’s get_logger_with_thread_id* function.

--- a/_reference/8.1.0/quali-shell-framework.md
+++ b/_reference/8.1.0/quali-shell-framework.md
@@ -132,7 +132,7 @@ Overall, we have six Runners, all base classes and their interfaces are located 
 
 * **[Run Command Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/run_command_runner.py)** – As you can see from the name, this Runner handles the `Run Custom Command` and `Run Custom Config Command` driver methods, and doesn’t require anything to implement besides the *cli_handler*. However, if you want to customize the `run_command_flow` property, you are welcome to override it. To initialize this runner, just pass the logger object.
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_run_command_runner.py).
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_configuration_runner.py).
 
 * **[State Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/state_runner.py)** – This runner is very similar to the Run Custom Command Runner as it only requires the *cli_handler* object to be implemented. It contains implementations for the `Health Check` and `Shutdown` commands. To initialize this runner, you need to pass the `logger`, `api` and `resource_config` objects mentioned in [Key Entities](#KeyEntities).
 

--- a/_reference/8.1.0/quali-shell-framework.md
+++ b/_reference/8.1.0/quali-shell-framework.md
@@ -136,8 +136,6 @@ Overall, we have six Runners, all base classes and their interfaces are located 
 
 * **[State Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/state_runner.py)** – This runner is very similar to the Run Custom Command Runner as it only requires the *cli_handler* object to be implemented. It contains implementations for the `Health Check` and `Shutdown` commands. To initialize this runner, you need to pass the `logger`, `api` and `resource_config` objects mentioned in [Key Entities](#KeyEntities).
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_state_runner.py).
-
 * **[Autoload Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/autoload_runner.py)** – discovers the device’s hardware structure and general details, such as the firmware version and model. This is the only runner that doesn’t require the *cli_handler* object, but requires the following properties to be implemented:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• snmp_handler

--- a/_reference/8.1.0/quali-shell-framework.md
+++ b/_reference/8.1.0/quali-shell-framework.md
@@ -12,7 +12,7 @@ version:
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this article, we will familiarize ourselves with the CloudShell Shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen Shells.
+In this article, we will familiarize ourselves with the CloudShell shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen shells.
 
 ## Introduction
 
@@ -201,4 +201,3 @@ We need to (1) pass the `session` object, command template and action/error maps
 {% highlight bash %}
 CommandTemplateExecutor(session, CONFIGURE_VLAN, action_map=action_map, error_map=error_map).execute_command(vlan_id=vlan_id)
 {% endhighlight %}
-

--- a/_reference/8.2.0/associating-service-categories.md
+++ b/_reference/8.2.0/associating-service-categories.md
@@ -2,7 +2,7 @@
 layout: page
 title: Associating Categories to 1st Gen Service Shells
 category: ref
-order: 10
+order: 11
 comments: true
 version:
     - 8.2.0

--- a/_reference/8.2.0/migrating_1st_gen_shells.md
+++ b/_reference/8.2.0/migrating_1st_gen_shells.md
@@ -2,7 +2,7 @@
 layout: page
 title: Converting 1st Gen Shells into 2nd Gen Shells
 category: ref
-order: 9
+order: 10
 comments: true
 version:
     - 8.2.0

--- a/_reference/8.2.0/quali-shell-framework.md
+++ b/_reference/8.2.0/quali-shell-framework.md
@@ -132,7 +132,7 @@ Overall, we have six Runners, all base classes and their interfaces are located 
 
 * **[Run Command Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/run_command_runner.py)** – As you can see from the name, this Runner handles the `Run Custom Command` and `Run Custom Config Command` driver methods, and doesn’t require anything to implement besides the *cli_handler*. However, if you want to customize the `run_command_flow` property, you are welcome to override it. To initialize this runner, just pass the logger object.
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_run_command_runner.py).
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_configuration_runner.py).
 
 * **[State Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/state_runner.py)** – This runner is very similar to the Run Custom Command Runner as it only requires the *cli_handler* object to be implemented. It contains implementations for the `Health Check` and `Shutdown` commands. To initialize this runner, you need to pass the `logger`, `api` and `resource_config` objects mentioned in [Key Entities](#KeyEntities).
 

--- a/_reference/8.2.0/quali-shell-framework.md
+++ b/_reference/8.2.0/quali-shell-framework.md
@@ -136,8 +136,6 @@ Overall, we have six Runners, all base classes and their interfaces are located 
 
 * **[State Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/state_runner.py)** – This runner is very similar to the Run Custom Command Runner as it only requires the *cli_handler* object to be implemented. It contains implementations for the `Health Check` and `Shutdown` commands. To initialize this runner, you need to pass the `logger`, `api` and `resource_config` objects mentioned in [Key Entities](#KeyEntities).
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For reference, see this [example](https://github.com/QualiSystems/cloudshell-networking-cisco/blob/dev/cloudshell/networking/cisco/runners/cisco_state_runner.py).
-
 * **[Autoload Runner](https://github.com/QualiSystems/cloudshell-networking-devices/blob/dev/cloudshell/devices/runners/autoload_runner.py)** – discovers the device’s hardware structure and general details, such as the firmware version and model. This is the only runner that doesn’t require the *cli_handler* object, but requires the following properties to be implemented:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;• snmp_handler

--- a/_reference/8.2.0/quali-shell-framework.md
+++ b/_reference/8.2.0/quali-shell-framework.md
@@ -12,7 +12,7 @@ version:
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this article, we will familiarize ourselves with the CloudShell Shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen Shells.
+In this article, we will familiarize ourselves with the CloudShell shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen shells.
 
 ## Introduction
 
@@ -201,4 +201,3 @@ We need to (1) pass the `session` object, command template and action/error maps
 {% highlight bash %}
 CommandTemplateExecutor(session, CONFIGURE_VLAN, action_map=action_map, error_map=error_map).execute_command(vlan_id=vlan_id)
 {% endhighlight %}
-

--- a/_reference/8.2.0/quali-shell-framework.md
+++ b/_reference/8.2.0/quali-shell-framework.md
@@ -1,33 +1,32 @@
 ---
 layout: page
-title: Customizing a Shell's Commands
-category: tut
-order: 18
+title: Quali’s Shell Framework
+category: ref
+order: 9
 comments: true
 version:
-    - 8.0.0
+    - 8.2.0
 ---
 
 
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this article, we will familiarize ourselves with the architecture of the shell's automation piece and learn how to develop and customize commands using the shell infrastructure. Note that this applies to 1st Gen and 2nd Gen shells.
+In this article, we will familiarize ourselves with the CloudShell Shell framework and learn how to leverage it to develop and customize commands. Note that this applies to 1st Gen and 2nd Gen Shells.
 
 ## Introduction
 
-CloudShell shells consist of a data model and a driver. The driver is written in python and can have python package dependencies. Quali’s officially released shells use a common set of python packages developed by Quali, which contain most of the logic of Quali shells, while the driver itself (the “.py” file inside the shell) is the thin layer which defines the interface with CloudShell along with the driver python requirements.
-
-Quali’s official shells have a granularity level of Vendor and OS, meaning that a shell supports all devices of a specific vendor and OS, and the exact functionality the shell exposes is defined in the relevant shell standard. The structure of the python packages reflects this granularity; for example, any logic which is common to all networking devices will reside in cloudshell-networking, any Cisco-specific logic will reside in cloudshell-networking-cisco and any Cisco IOS-specific logic will reside in cloudshell-networking-cisco-ios.
-
-When creating your own shell from scratch, or when extending an official Quali shell by adding/modifying commands, it is recommended to leverage Quali’s shell infrastructure and python packages. Adding new commands or customizing existing ones should be done in the python driver that resides in the shell itself. You can write your code directly there or you can place it in a separate python package that you’ll add as a requirement to the driver. Such custom python packages can be loaded into our local [PyPi server](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Cnfgr-Pyth-Env-Wrk-Offln.htm?Highlight=pypi) and thus be available to your entire CloudShell deployment.
+Every CloudShell shell consists of a data model and a driver. The driver is written in python and can have python package dependencies. Quali’s officially released shells use a common set of python packages developed by Quali, which contain most of the logic of Quali shells, while the driver itself (the “.py” file inside the shell) is the thin layer that defines the interface with CloudShell along with the driver’s python requirements.
+Quali’s official shells have a granularity level of Vendor and OS. This means that each official shell supports all devices of a specific vendor and OS. The exact functionality that is exposed by the shell is defined in the relevant shell standard. The structure of the python packages reflects this granularity – for example, any logic that is common to all networking devices resides in cloudshell-networking, while any Cisco-specific logic resides in cloudshell-networking-cisco, and any Cisco IOS-specific logic resides in cloudshell-networking-cisco-ios.
+It is possible to use Quali’s shell framework when creating your own shells or customizing existing ones. Note that using the framework is optional.
+To work with one or more of the framework’s python packages, you need to list it in your shell project’s requirements, and not fork it or directly edit it. Then you can either write the code, which uses the package, directly in the shell’s driver or create your own python package and add it to the requirements of the driver. Such custom python packages can be loaded into our [PyPi server](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Cnfgr-Pyth-Env-Wrk-Offln.htm?Highlight=pypi) and thus be available to your entire CloudShell deployment.
 
 **Important:** It is not recommended to modify Quali python packages as these changes may be overwritten if a newer package that has the same file name is published on the public PyPi repository. Alternatively, you’re welcome to create your own packages, using our python packages as a reference.
 
 
 ## Python package structure
 
-The following diagram shows the python classes used by the shell commands and their dependencies.
+The following diagram shows the python classes used by the shell commands and their dependencies:
 
 ![Python Package Structure Diagram]({{ site.baseurl}}/assets/python-package-structure.png)
 
@@ -45,7 +44,7 @@ An additional element that is used by the runners is the communication handler, 
  
 ## Key Entities<a name="KeyEntities"></a>
 
-There are several objects that should be initialized in the python driver, to allow you to work with Quali's infrastructure:
+There are several objects that must be initialized in the python driver, to allow you to work with Quali's infrastructure:
 * **cli** - A Python package that provides an easy abstraction interface for CLI access and communication (Telnet, TCP, SSH etc.) for network devices. The CLI class instance is provided by `cloudshell.cli.cli`. It must be created when the driver is initializing, since it allows the shell to designate a single session pool for all of the shell’s commands. You are welcome to use the *_get_cli* helper from *driver_helper* mentioned above. *_get_cli* allows you to define the session pool’s size and idle timeout. 
 * **api** is an instance of the *cloudshell-automation-API*’s *CloudShellAPISession* class. It must be created on every command execution. This class has a helper named *_get_api*, which is also provided by the *driver_helper* mentioned above.
 * **logger** is a logger object from *cloudshell-core*. It is recommended to use the *driver_helper’s get_logger_with_thread_id* function.

--- a/_shells/7.1.0/getting-started.md
+++ b/_shells/7.1.0/getting-started.md
@@ -13,7 +13,7 @@ version:
 
 This section will take you through the basic steps of a creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to instancing Shell resources and running commands in CloudShell. 
 
-_**Before developing shells, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing shells, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### Prerequisites
 * [Get CloudShell](http://info.quali.com/cloudshell-developer-edition-download): Download the latest CloudShell SDK and run it on your machine.  

--- a/_shells/8.0.0/common-driver-recipes.md
+++ b/_shells/8.0.0/common-driver-recipes.md
@@ -74,7 +74,7 @@ We can easily modify the previous code to do that instead:
 {% github_sample QualiSystems/devguide_examples/blob/master/common_driver_recipes/src/driver.py 57 70 %}
 {% endhighlight %}
 
-#### Sending commands to a networking device?
+#### Sending commands to a networking device
 When adding a new command that requires communication with a networking device, such as a switch or router, you need to open a session to the device. An easy way to do that is by leveraging Quali’s shell framework (*cloudshell-cli* package). The framework can provide a session from a session pool via Telnet, SSH or TCP, based on the configuration saved in the **CLI Connection Type** attribute on the root resource.
 
 See the code below for an example:

--- a/_shells/8.0.0/common-driver-recipes.md
+++ b/_shells/8.0.0/common-driver-recipes.md
@@ -73,3 +73,9 @@ We can easily modify the previous code to do that instead:
 {% highlight python %}
 {% github_sample QualiSystems/devguide_examples/blob/master/common_driver_recipes/src/driver.py 57 70 %}
 {% endhighlight %}
+
+#### Sending commands to a networking device?
+When adding a new command that requires communication with a networking device, such as a switch or router, you need to open a session to the device. An easy way to do that is by leveraging Quali’s shell framework (*cloudshell-cli* package). The framework can provide a session from a session pool via Telnet, SSH or TCP, based on the configuration saved in the **CLI Connection Type** attribute on the root resource.
+
+See the code below for an example:
+[TBD code snippet]

--- a/_shells/8.0.0/customizing-driver-commands.md
+++ b/_shells/8.0.0/customizing-driver-commands.md
@@ -21,7 +21,7 @@ In this section we'll explore the different ways in which these commands can be 
 * [Optional parameters and default values](#customizing_optional_parameters)
 * [Restricting input to a specific set of possible values](#customizing_lookup_values)
 * [Adding categories](#customizing_categories)
-* [Orchestration only commands](#customizing_orchestration_only_commands)
+* [Orchestration only commands (hidden commands)](#customizing_orchestration_only_commands)
 
 If you haven't done some already it is recommended to go through the [Getting Started]({{site.baseurl}}/shells/{{pageVersion}}/getting-started.html) tutorial before continuing to get a better understanding of the overall process of creating and using a shell. We also assume you've gone through the steps described in the [Setting Up the Development IDE]({{site.baseurl}}/introduction/{{pageVersion}}/setting-up-the-development-ide.html) section of this guide.
 
@@ -225,10 +225,10 @@ After re-installing the shell we get the following command panel layout:
 
 <a name="customizing_orchestration_only_commands"></a>
 
-### Orchestration only commands
+### Orchestration only commands (hidden commands)
 
-Sometimes, you may wish to create commands that are intended to be used as a part of an orchestration flow, for example to be called during setup, but that you don't wish users to get direct access to or to be visible via the UI. For example, a command that will be called during a sandbox’s Setup process.
-To support this use case, CloudShell supports a special category, the _Hidden Commands_ category which allows you to mark commands you want to be omitted from the web portal UI but that can still be invoked via the API.
+Sometimes, you may wish to create commands that are intended to be used as a part of an orchestration flow, for example to be called during setup, but want these commands to be inaccessible to users [hidden] from the UI. For example, a command that is called during a sandbox’s Setup process.
+To support this use case, CloudShell supports a special category, the _Hidden Commands_ category, which allows you to omit commands from the web portal UI while allowing them to be invoked via the API.
 
 To demonstrate this capability, let's first add a new function to our driver class in the _driver.py_ file:
 

--- a/_shells/8.0.0/customizing-shells.md
+++ b/_shells/8.0.0/customizing-shells.md
@@ -19,7 +19,7 @@ Customizing an existing Shell is done using the `shellfoundry extend` command. T
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/shells/{{pageVersion}}/customizing-shell-commands.html).
+To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
 CloudShell provides two ways to customize attributes:
 * Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 

--- a/_shells/8.0.0/customizing-shells.md
+++ b/_shells/8.0.0/customizing-shells.md
@@ -13,9 +13,9 @@ version:
 
 In this section, we’ll learn how to create and modify a shell’s commands and attributes.
 
-Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell’s Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. 
+Customizing an existing shell is done using the `shellfoundry extend` command. This command downloads the source code of the shell you wish to customize to your local machine and updates the shell’s Author. Note that extending official shells (shells that were released by Quali) will remove their official tag. 
 
-The common use cases for customizing or extending a Shell are:
+The common use cases for customizing or extending a shell are:
 
 * Adding new attributes
 * Modifying existing attributes
@@ -23,15 +23,11 @@ The common use cases for customizing or extending a Shell are:
 * Modifying existing commands
 
 
-## Customizing a shell’s Commands
+## Customizing a shell’s commands
 
 When customizing an official shell you can add new commands, and also modify or hide existing ones.
 
-**To add a new command:**
-
-1)  Add the command in the shell’s driver.py file.
-
-2) Expose the command in the shell’s *drivermetadata.xml* file.
+* **To add a new command:** Add the command in the shell’s driver.py file, and expose the command in the shell’s *drivermetadata.xml* file.
 
 The command’s logic should be placed either in the driver itself or in a separate python package.
 
@@ -45,34 +41,34 @@ It is also possible to hide or remove a command. Hiding a command is done by pla
 
 When adding or modifying a command, you can leverage Quali’s shell framework to ease the development process, see more information [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
-See some common examples for shell’s command extension in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
+See some common command extension examples in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
 
 
 ## Customizing a shell’s attributes
 
 CloudShell provides two ways to customize attributes:
 
-* **Customizing an existing Shell**: Use this option when the modifications are related to a specific device but are not relevant to other Shells. This is done by manually editing the Shell’s *shell-definition.yaml* file.
-* **Associating custom attributes with a Shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute.
+* **Customizing an existing shell**: Use this option when the modifications are related to a specific device but are not relevant to other shells. This is done by manually editing the shell’s *shell-definition.yaml* file.
+* **Associating custom attributes with a shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple shells. For example, the Execution Server Selector attribute.
 
 The second option of associating custom attributes with an already installed shell is done by calling the [SetCustomShellAttribute]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html#SetCustomShellAttribute) API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html). The first option currently only applies to the root model of the shell, so if you need to customize your shell’s sub-resource models, such as blades and ports, use the second option. Note that CloudShell version 9.0 will support sub-resource attribute modifications via the *shell-definition.yaml* file.
 
-**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original Shell is based on.
+**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original shell is based on.
 
 
-### Adding attributes to a Shell’s model
+### Adding attributes to a shell’s model
 
 The shell’s path can be a URL to the shell template’s zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
 
-**To add attributes to a Shell’s root model:**
+**To add attributes to a shell’s root model:**
 
 1)  Open command-line.
 
-2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template’s root folder.
+2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original shell template’s root folder.
 
 3) Run the following in command-line:
 
-{% highlight bash %}shellfoundy extend <URL/path-to-Shell-template>{% endhighlight %}
+{% highlight bash %}shellfoundy extend <URL/path-to-shell-template>{% endhighlight %}
 
 4) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
@@ -138,7 +134,7 @@ properties:
 {% endhighlight %}
 
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the Modeling Shells with TOSCA.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).
 
 4) Replace `<property_name>` with the attribute’s name. Do not remove the colon (:) from the end of the line.
 

--- a/_shells/8.0.0/customizing-shells.md
+++ b/_shells/8.0.0/customizing-shells.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Customizing a 2nd Gen Shell's Attributes
+title: Customizing Shells
 category: tut
 order: 13
 comments: true
@@ -11,53 +11,78 @@ version:
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this section, we’ll learn how to configure and modify attributes in a Shell.
+In this section, we’ll learn how to create and modify a shell’s commands and attributes.
 
-Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell's Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. The common use cases for customizing or extending a Shell are:
+Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell’s Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. 
+
+The common use cases for customizing or extending a Shell are:
+
 * Adding new attributes
 * Modifying existing attributes
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+
+## Customizing a shell’s Commands
+
+When customizing an official shell you can add new commands, and also modify or hide existing ones.
+
+**To add a new command:**
+
+1)  Add the command in the shell’s driver.py file.
+
+2) Expose the command in the shell’s *drivermetadata.xml* file.
+
+The command’s logic should be placed either in the driver itself or in a separate python package.
+
+Modifications to a command can include adding some logic either before or after the command or changing the command logic itself. In order to do that, **copy the command code** from the original Quali python package to the shell driver or to the custom python package you created (*the command logic resides either in the vendor package or vendor-os package - for example in “cloudshell-cisco” or “cloudshell-cisco-ios”*).
+
+When modifying an existing command, you can add optional input parameters. Just make sure that the implementation is backwards compatible. Note that adding mandatory inputs or removing one of the original inputs is not supported. In these cases, it is recommended to create an additional command with a different name, instead of modifying an existing one.
+
+[TBD – code example]
+
+It is also possible to hide or remove a command. Hiding a command is done by placing it in an “administrative” [category]({{site.baseurl}}/shells/{{pageVersion}}/customizing-driver-commands.html) in the drivermetadata.xml. Note that removing a command might affect how the shell is used since CloudShell and/or some orchestration scripts might depend on the existing driver’s commands.
+
+When adding or modifying a command, you can leverage Quali’s shell framework to ease the development process, see more information [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+
+See some common examples for shell’s command extension in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
+
+
+## Customizing a shell’s attributes
 
 CloudShell provides two ways to customize attributes:
-* Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 
-This is done by manually editing the Shell’s **shell-definition.yaml** file.
-* Associating custom attributes with a Shell that is installed in CloudShell: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute. 
 
-The second option of associating custom attributes with an already installed shell is done by calling the `SetCustomShellAttribute` API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html).
-The first option currently only applies to the root model of the Shell, so if you need to customize your Shell’s sub-resource models, such as blades and ports, use the second option. Note that version 9.0 will support sub-resource attribute modifications via the **shell-definition.yaml** file.
+* **Customizing an existing Shell**: Use this option when the modifications are related to a specific device but are not relevant to other Shells. This is done by manually editing the Shell’s *shell-definition.yaml* file.
+* **Associating custom attributes with a Shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute.
 
-Note that deleting a 2nd Gen Shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen Shell's data model (families and models) and its structure, which is as defined in the relevant Shell standard the original Shell is based on.
+The second option of associating custom attributes with an already installed shell is done by calling the [SetCustomShellAttribute]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html#SetCustomShellAttribute) API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html). The first option currently only applies to the root model of the shell, so if you need to customize your shell’s sub-resource models, such as blades and ports, use the second option. Note that CloudShell version 9.0 will support sub-resource attribute modifications via the *shell-definition.yaml* file.
 
+**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original Shell is based on.
 
 
-### Adding attributes to a Shell's model
+### Adding attributes to a Shell’s model
 
-The Shell's path can be a URL to the Shell template's zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the Shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
+The shell’s path can be a URL to the shell template’s zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
 
 **To add attributes to a Shell’s root model:**
 
-1) Open command-line.
+1)  Open command-line.
 
-2) To extend a Shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template's root folder.
+2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template’s root folder.
 
 3) Run the following in command-line:
 
-{% highlight bash %}
-shellfoundy extend <URL/path-to-Shell-template>
-{% endhighlight %}
+{% highlight bash %}shellfoundy extend <URL/path-to-Shell-template>{% endhighlight %}
 
-4) In the Shell’s download folder, open the _shell-definition.yaml_ file in your preferred editor.
+4) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
 5) Locate `node-types:`.
 
 6) Under the root level model, add the following lines:
 
 {% highlight bash %}
-    properties:
-     property_name:
+properties:
+     <property_name>:
        type: string
        default: fast
        description: Some attribute description
@@ -65,48 +90,45 @@ shellfoundy extend <URL/path-to-Shell-template>
          - valid_values: [fast, slow]
        tags: [configuration, setting, not_searchable, abstract_filter, include_in_insight, readonly_to_users display_in_diagram, connection_attribute, read_only]
 {% endhighlight %}
-  
-7) Edit their settings, as appropriate. For  additional information on these settings, see the CloudShell online help.
+
+7) Edit their settings, as appropriate. For additional information on these settings, see the CloudShell online help.
 
 |  Properties        |  Description 
 |  :----------------   | :----------------------------------------------------------------- |            
-|  property_name     |  Attribute's name                        |
-|  type            |   Type of attribute. Optional values: string, integer, float, boolean, cloudshell.datatypes.Password  |
-|  default       |  Default value.                           |
-|  description          |  Attribute's description                                   |
-|  constraints              |  Permitted values       |
-|  tags              |  Attribute rules. For details, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).            |
+|  `<property_name>`     |  Replace `<property_name>` with the new attribute’s display name. Do not remove the colon (:) from the end of the line.            |
+|  `type`            |   Type of attribute. Optional values: string, integer, float, boolean, cloudshell.datatypes.Password  |
+|  `default`       |  Default value.                           |
+|  `description`          |  Attribute's description                                   |
+|  `constraints`              |  Permitted values       |
+|  `tags`              |  Attribute rules. For details, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).            |
 
 8) Remove any unneeded lines.
 
 9) Save the file.
 
-10) In command-line, navigate to the Shell’s root folder.
+10) In command-line, navigate to the shell’s root folder.
 
-11) Package the Shell.
+11) Package the shell.
 
 {% highlight bash %}shellfoundry pack{% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the Shell to CloudShell:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the shell to CloudShell:
 
 {% highlight bash %}shellfoundry install{% endhighlight %}
-
-
-
 
 ### Modifying an existing attribute
 
 **To modify an attribute’s rules:**
 
-1) Download the Shell template, as explained in the above section.
+1) Download the shell template, as explained in the above section.
 
-2) In the Shell’s download folder, open the **shell-definition.yaml** file in your preferred editor.
+2) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
 3) Under `node-types:`, add the following lines.
 
 {% highlight bash %}
-    properties:
-     property_name:
+properties:
+     <property_name>:
        type: string
        default: fast
        description: Some attribute description
@@ -115,22 +137,23 @@ shellfoundy extend <URL/path-to-Shell-template>
        tags: [configuration, setting, not_searchable, abstract_filter, include_in_insight, readonly_to_users display_in_diagram, connection_attribute, read_only]
 {% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).
 
-4) Replace `property_name` with the attribute’s name. Do not remove the colon (`:`} from the end of the line.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the Modeling Shells with TOSCA.
 
-5) Edit the attribute's settings. 
+4) Replace `<property_name>` with the attribute’s name. Do not remove the colon (:) from the end of the line.
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Note:** You cannot modify attributes **type**, **name**, and any attributes that are associated with the Shell's family as this will affect other Shells that use this family.
+5) Edit the attribute’s settings.
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Note:** You cannot modify attributes **type**, **name**, and any attributes that are associated with the shell’s family as this will affect other shells that use this family.
 
 6) Save the file.
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The attribute is updated.
 
-7) In command-line, navigate to the Shell's folder and package the Shell.
+7) In command-line, navigate to the shell’s folder and package the shell.
 
 {% highlight bash %}shellfoundry pack{% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the Shell to CloudShell:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the shell to CloudShell:
 
 {% highlight bash %}shellfoundry install{% endhighlight %}

--- a/_shells/8.0.0/customizing-shells.md
+++ b/_shells/8.0.0/customizing-shells.md
@@ -19,7 +19,7 @@ Customizing an existing Shell is done using the `shellfoundry extend` command. T
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+To learn how to add and customize commands, see [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
 CloudShell provides two ways to customize attributes:
 * Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 

--- a/_shells/8.0.0/deploying-to-production.md
+++ b/_shells/8.0.0/deploying-to-production.md
@@ -30,7 +30,7 @@ This will create two artifacts in the 'dist' sub-folder of the Shell project:
 1. A zip file archive called _\<shellname\>.zip_ - This is the Shell distributable package
 2. A folder named _offline_requirements_ - The Python packages required by the Shell. This folder should be used with any offline execution servers, i.e. execution servers where pip will not be able to reach the internet to download the packages specified in requirements.txt
 
-### Adding custom attributes to the Shell
+### Adding custom attributes to the Shell<a name="SetCustomShellAttribute"></a>
 
 Using the API, you can add attributes to your Shell and customize their defaults for this Shell. This is done using the `SetCustomShellAttribute` API method, available in the TestShell XML RPC and Python APIs. 
 

--- a/_shells/8.0.0/driver-deep-dive.md
+++ b/_shells/8.0.0/driver-deep-dive.md
@@ -160,7 +160,7 @@ Re-install the shell. You'll now see the commands pane has a regular stop button
 stop button the _is_cancelled_ property on the _cancellation_context_ object will be updated and the driver will get a chance to
 complete its current actions and end its execution.
 
-#### Drivers and concurrency
+#### Drivers and concurrency<a name="drivers-and-concurrency"></a>
 
 CloudShell supports two modes for drivers:
 

--- a/_shells/8.0.0/getting-started.md
+++ b/_shells/8.0.0/getting-started.md
@@ -11,16 +11,36 @@ version:
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to instancing Shell resources and running commands in CloudShell.
+In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to creating Shell resources and running commands in CloudShell.
 
 _**Before developing shells, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a personal edition of CloudShell on which you can perform your training and development activities.**_
+
+### What is a shell?
+
+A Shell enables CloudShell users to interact with different sandbox elements, like physical devices and virtual appliances. A Shell models the sandbox element in CloudShell and provides commands that CloudShell users and automation processes can run on it, like Power On and Health Check.
+
+In our [community](http://community.quali.com/spaces/12/index.html?__hstc=46213176.aaafbe5adb338215377a985e0c025079.1467146361756.1471392182746.1471395614692.11&__hssc=46213176.1.1471395614692&__hsfp=2437115919), you can find both officially released shells and shells developed in our developer community. If you find a shell that fits your needs, you’re welcome to use it as is, or, you can customize its settings and automation, as explained in [Customizing Shells]({{site.baseurl}}/shells/{{pageVersion}}/customizing-shells.html). If you can’t find the shell you’re looking for, you’re welcome to create a new one from scratch using one of our shell standard templates and contribute it to the community for others to use it as well.
+
+Historically, we have had two types of shells in CloudShell, 1st Generation shells and 2nd Generation shells. While 1st Gen shells are still used, all new shells are released only as 2nd Generation shells and this developer guide focuses on this type of shells. For additional information, see CloudShell Help's [Shells Overview](http://help.quali.com/Online%20Help/8.0.0.7741/Portal/Content/CSP/LAB-MNG/Shells.htm).
+
+The basic shell creation process is as follows:
+
+1)  Install shellfoundry, our command-line utility for creating and managing the shell development process
+
+2)  Create or customize a shell. 
+
+3)  Upload the shell to CloudShell.
+
+4)  If the shell requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See CloudShell help's help's [Updating Python Dependencies for Shells and Drivers](http://help.quali.com/Online%20Help/8.0.0.7741/Portal/Content/Admn/Updt-Python-Libs.htm).
+
+5)  Create resources in the appropriate domains.
 
 ### Supported versions - CloudShell v.8.0 and up
 As of version 8.0, CloudShell supports 2nd Gen Shells. This guide includes instructions on developing **2nd Gen Shells only**.
 
 For information on developing 1st Gen Shells, see [CloudShell Developer Guide](https://qualisystems.github.io/devguide_7/) CloudShell v7.1 and below.
 
-To learn more about the  different versions of the Shells used by CloudShell and how to upgrade a 1st Gen Shell, see [Converting 1st Generation Shells]({{site.baseurl}}/reference/{{pageVersion}}/migrating_1st_gen_shells.html)
+To learn more about the  different versions of the Shells used by CloudShell and how to upgrade a 1st Gen Shell, see [Converting 1st Generation Shells]({{site.baseurl}}/reference/{{pageVersion}}/migrating_1st_gen_shells.html).
 
 
 

--- a/_shells/8.0.0/getting-started.md
+++ b/_shells/8.0.0/getting-started.md
@@ -13,7 +13,7 @@ version:
 
 In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to creating Shell resources and running commands in CloudShell.
 
-_**Before developing shells, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a personal edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing shells, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### What is a shell?
 

--- a/_shells/8.0.0/modeling-the-shell.md
+++ b/_shells/8.0.0/modeling-the-shell.md
@@ -291,25 +291,7 @@ artifacts:
 
 
 
-#### Add Shell Capabilities
-The Shell’s standard already defines basic capabilities that can be implemented in the Shell. For example, support for SNMP, console connections, device backup and Auto-discovery. The capabilities that are relevant for the Shell are already defined in the Shell’s standard.
-In the _capabilities_ section, we can add additional capabilities or edit the standard capabilities.
+#### Optional Shell Capabilities
+The Shell supports two capabilities that can be enabled, assuming the Shell's driver supports them: auto discovery and concurrent execution of commands.
 
-
-{% highlight yaml %}
-capabilities:
-  auto_discovery_capability:
-    type: cloudshell.capabilities.AutoDiscovery
-    properties:        
-      enable_auto_discovery:
-        type: boolean
-        default: true
-      auto_discovery_description:
-        type: string
-        default: Describe the auto discovery
-      inventory_description:
-        type: string
-        default: Describe the resource shell template
-{% endhighlight %}
-
-The most common use case is customizing the Auto-discovery process. This is covered in detail in [Auto Discovery For Inventory Shells]({{site.baseurl}}/shells/{{pageVersion}}/implementing-discovery-for-inventory-shells.html)
+The implementation of these capabilities is covered in detail in [Auto Discovery For Inventory Shells]({{site.baseurl}}/shells/{{pageVersion}}/implementing-discovery-for-inventory-shells.html) and the Driver Deep Dive article's [Drivers and concurrency]({{site.baseurl}}/shells/{{pageVersion}}/driver-deep-dive.html#drivers-and-concurrency) section.

--- a/_shells/8.1.0/common-driver-recipes.md
+++ b/_shells/8.1.0/common-driver-recipes.md
@@ -74,7 +74,7 @@ We can easily modify the previous code to do that instead:
 {% github_sample QualiSystems/devguide_examples/blob/master/common_driver_recipes/src/driver.py 57 70 %}
 {% endhighlight %}
 
-#### Sending commands to a networking device?
+#### Sending commands to a networking device
 When adding a new command that requires communication with a networking device, such as a switch or router, you need to open a session to the device. An easy way to do that is by leveraging Quali’s shell framework (*cloudshell-cli* package). The framework can provide a session from a session pool via Telnet, SSH or TCP, based on the configuration saved in the **CLI Connection Type** attribute on the root resource.
 
 See the code below for an example:

--- a/_shells/8.1.0/common-driver-recipes.md
+++ b/_shells/8.1.0/common-driver-recipes.md
@@ -73,3 +73,9 @@ We can easily modify the previous code to do that instead:
 {% highlight python %}
 {% github_sample QualiSystems/devguide_examples/blob/master/common_driver_recipes/src/driver.py 57 70 %}
 {% endhighlight %}
+
+#### Sending commands to a networking device?
+When adding a new command that requires communication with a networking device, such as a switch or router, you need to open a session to the device. An easy way to do that is by leveraging Quali’s shell framework (*cloudshell-cli* package). The framework can provide a session from a session pool via Telnet, SSH or TCP, based on the configuration saved in the **CLI Connection Type** attribute on the root resource.
+
+See the code below for an example:
+[TBD code snippet]

--- a/_shells/8.1.0/customizing-driver-commands.md
+++ b/_shells/8.1.0/customizing-driver-commands.md
@@ -21,7 +21,7 @@ In this section we'll explore the different ways in which these commands can be 
 * [Optional parameters and default values](#customizing_optional_parameters)
 * [Restricting input to a specific set of possible values](#customizing_lookup_values)
 * [Adding categories](#customizing_categories)
-* [Orchestration only commands](#customizing_orchestration_only_commands)
+* [Orchestration only commands (hidden commands)](#customizing_orchestration_only_commands)
 
 If you haven't done some already it is recommended to go through the [Getting Started]({{site.baseurl}}/shells/{{pageVersion}}/getting-started.html) tutorial before continuing to get a better understanding of the overall process of creating and using a shell. We also assume you've gone through the steps described in the [Setting Up the Development IDE]({{site.baseurl}}/introduction/{{pageVersion}}/setting-up-the-development-ide.html) section of this guide.
 
@@ -225,10 +225,10 @@ After re-installing the shell we get the following command panel layout:
 
 <a name="customizing_orchestration_only_commands"></a>
 
-### Orchestration only commands
+### Orchestration only commands (hidden commands)
 
-Sometimes, you may wish to create commands that are intended to be used as a part of an orchestration flow, for example to be called during setup, but that you don't wish users to get direct access to or to be visible via the UI. For example, a command that will be called during a sandbox’s Setup process.
-To support this use case, CloudShell supports a special category, the _Hidden Commands_ category which allows you to mark commands you want to be omitted from the web portal UI but that can still be invoked via the API.
+Sometimes, you may wish to create commands that are intended to be used as a part of an orchestration flow, for example to be called during setup, but want these commands to be inaccessible to users [hidden] from the UI. For example, a command that is called during a sandbox’s Setup process.
+To support this use case, CloudShell supports a special category, the _Hidden Commands_ category, which allows you to omit commands from the web portal UI while allowing them to be invoked via the API.
 
 To demonstrate this capability, let's first add a new function to our driver class in the _driver.py_ file:
 

--- a/_shells/8.1.0/customizing-shells.md
+++ b/_shells/8.1.0/customizing-shells.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Customizing a 2nd Gen Shell's Attributes
+title: Customizing Shells
 category: tut
 order: 13
 comments: true
@@ -8,56 +8,82 @@ version:
     - 8.1.0
 ---
 
+
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this section, we’ll learn how to configure and modify attributes in a Shell.
+In this section, we’ll learn how to create and modify a shell’s commands and attributes.
 
-Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell's Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. The common use cases for customizing or extending a Shell are:
+Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell’s Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. 
+
+The common use cases for customizing or extending a Shell are:
+
 * Adding new attributes
 * Modifying existing attributes
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+
+## Customizing a shell’s Commands
+
+When customizing an official shell you can add new commands, and also modify or hide existing ones.
+
+**To add a new command:**
+
+1)  Add the command in the shell’s driver.py file.
+
+2) Expose the command in the shell’s *drivermetadata.xml* file.
+
+The command’s logic should be placed either in the driver itself or in a separate python package.
+
+Modifications to a command can include adding some logic either before or after the command or changing the command logic itself. In order to do that, **copy the command code** from the original Quali python package to the shell driver or to the custom python package you created (*the command logic resides either in the vendor package or vendor-os package - for example in “cloudshell-cisco” or “cloudshell-cisco-ios”*).
+
+When modifying an existing command, you can add optional input parameters. Just make sure that the implementation is backwards compatible. Note that adding mandatory inputs or removing one of the original inputs is not supported. In these cases, it is recommended to create an additional command with a different name, instead of modifying an existing one.
+
+[TBD – code example]
+
+It is also possible to hide or remove a command. Hiding a command is done by placing it in an “administrative” [category]({{site.baseurl}}/shells/{{pageVersion}}/customizing-driver-commands.html) in the drivermetadata.xml. Note that removing a command might affect how the shell is used since CloudShell and/or some orchestration scripts might depend on the existing driver’s commands.
+
+When adding or modifying a command, you can leverage Quali’s shell framework to ease the development process, see more information [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+
+See some common examples for shell’s command extension in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
+
+
+## Customizing a shell’s attributes
 
 CloudShell provides two ways to customize attributes:
-* Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 
-This is done by manually editing the Shell’s **shell-definition.yaml** file.
-* Associating custom attributes with a Shell that is installed in CloudShell: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute. 
 
-The second option of associating custom attributes with an already installed shell is done by calling the `SetCustomShellAttribute` API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html).
-The first option currently only applies to the root model of the Shell, so if you need to customize your Shell’s sub-resource models, such as blades and ports, use the second option. Note that version 9.0 will support sub-resource attribute modifications via the **shell-definition.yaml** file.
+* **Customizing an existing Shell**: Use this option when the modifications are related to a specific device but are not relevant to other Shells. This is done by manually editing the Shell’s *shell-definition.yaml* file.
+* **Associating custom attributes with a Shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute.
 
-Note that deleting a 2nd Gen Shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen Shell's data model (families and models) and its structure, which is as defined in the relevant Shell standard the original Shell is based on.
+The second option of associating custom attributes with an already installed shell is done by calling the [SetCustomShellAttribute]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html#SetCustomShellAttribute) API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html). The first option currently only applies to the root model of the shell, so if you need to customize your shell’s sub-resource models, such as blades and ports, use the second option. Note that CloudShell version 9.0 will support sub-resource attribute modifications via the *shell-definition.yaml* file.
 
+**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original Shell is based on.
 
 
-### Adding attributes to a Shell's model
+### Adding attributes to a Shell’s model
 
-The Shell's path can be a URL to the Shell template's zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the Shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
+The shell’s path can be a URL to the shell template’s zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
 
 **To add attributes to a Shell’s root model:**
 
-1) Open command-line.
+1)  Open command-line.
 
-2) To extend a Shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template's root folder.
+2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template’s root folder.
 
 3) Run the following in command-line:
 
-{% highlight bash %}
-shellfoundy extend <URL/path-to-Shell-template>
-{% endhighlight %}
+{% highlight bash %}shellfoundy extend <URL/path-to-Shell-template>{% endhighlight %}
 
-4) In the Shell’s download folder, open the _shell-definition.yaml_ file in your preferred editor.
+4) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
 5) Locate `node-types:`.
 
 6) Under the root level model, add the following lines:
 
 {% highlight bash %}
-    properties:
-     property_name:
+properties:
+     <property_name>:
        type: string
        default: fast
        description: Some attribute description
@@ -65,48 +91,45 @@ shellfoundy extend <URL/path-to-Shell-template>
          - valid_values: [fast, slow]
        tags: [configuration, setting, not_searchable, abstract_filter, include_in_insight, readonly_to_users display_in_diagram, connection_attribute, read_only]
 {% endhighlight %}
-  
-7) Edit their settings, as appropriate. For  additional information on these settings, see the CloudShell online help.
+
+7) Edit their settings, as appropriate. For additional information on these settings, see the CloudShell online help.
 
 |  Properties        |  Description 
 |  :----------------   | :----------------------------------------------------------------- |            
-|  property_name     |  Attribute's name                        |
-|  type            |   Type of attribute. Optional values: string, integer, float, boolean, cloudshell.datatypes.Password  |
-|  default       |  Default value.                           |
-|  description          |  Attribute's description                                   |
-|  constraints              |  Permitted values       |
-|  tags              |  Attribute rules. For details, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).            |
+|  `<property_name>`     |  Replace `<property_name>` with the new attribute’s display name. Do not remove the colon (:) from the end of the line.            |
+|  `type`            |   Type of attribute. Optional values: string, integer, float, boolean, cloudshell.datatypes.Password  |
+|  `default`       |  Default value.                           |
+|  `description`          |  Attribute's description                                   |
+|  `constraints`              |  Permitted values       |
+|  `tags`              |  Attribute rules. For details, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).            |
 
 8) Remove any unneeded lines.
 
 9) Save the file.
 
-10) In command-line, navigate to the Shell’s root folder.
+10) In command-line, navigate to the shell’s root folder.
 
-11) Package the Shell.
+11) Package the shell.
 
 {% highlight bash %}shellfoundry pack{% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the Shell to CloudShell:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the shell to CloudShell:
 
 {% highlight bash %}shellfoundry install{% endhighlight %}
-
-
-
 
 ### Modifying an existing attribute
 
 **To modify an attribute’s rules:**
 
-1) Download the Shell template, as explained in the above section.
+1) Download the shell template, as explained in the above section.
 
-2) In the Shell’s download folder, open the **shell-definition.yaml** file in your preferred editor.
+2) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
 3) Under `node-types:`, add the following lines.
 
 {% highlight bash %}
-    properties:
-     property_name:
+properties:
+     <property_name>:
        type: string
        default: fast
        description: Some attribute description
@@ -115,22 +138,23 @@ shellfoundy extend <URL/path-to-Shell-template>
        tags: [configuration, setting, not_searchable, abstract_filter, include_in_insight, readonly_to_users display_in_diagram, connection_attribute, read_only]
 {% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).
 
-4) Replace `property_name` with the attribute’s name. Do not remove the colon (`:`} from the end of the line.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the Modeling Shells with TOSCA.
 
-5) Edit the attribute's settings. 
+4) Replace `<property_name>` with the attribute’s name. Do not remove the colon (:) from the end of the line.
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Note:** You cannot modify attributes **type**, **name**, and any attributes that are associated with the Shell's family as this will affect other Shells that use this family.
+5) Edit the attribute’s settings.
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Note:** You cannot modify attributes **type**, **name**, and any attributes that are associated with the shell’s family as this will affect other shells that use this family.
 
 6) Save the file.
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The attribute is updated.
 
-7) In command-line, navigate to the Shell's folder and package the Shell.
+7) In command-line, navigate to the shell’s folder and package the shell.
 
 {% highlight bash %}shellfoundry pack{% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the Shell to CloudShell:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the shell to CloudShell:
 
 {% highlight bash %}shellfoundry install{% endhighlight %}

--- a/_shells/8.1.0/customizing-shells.md
+++ b/_shells/8.1.0/customizing-shells.md
@@ -19,7 +19,7 @@ Customizing an existing Shell is done using the `shellfoundry extend` command. T
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/shells/{{pageVersion}}/customizing-shell-commands.html).
+To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
 CloudShell provides two ways to customize attributes:
 * Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 

--- a/_shells/8.1.0/customizing-shells.md
+++ b/_shells/8.1.0/customizing-shells.md
@@ -8,15 +8,14 @@ version:
     - 8.1.0
 ---
 
-
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
 In this section, we’ll learn how to create and modify a shell’s commands and attributes.
 
-Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell’s Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. 
+Customizing an existing shell is done using the `shellfoundry extend` command. This command downloads the source code of the shell you wish to customize to your local machine and updates the shell’s Author. Note that extending official shells (shells that were released by Quali) will remove their official tag. 
 
-The common use cases for customizing or extending a Shell are:
+The common use cases for customizing or extending a shell are:
 
 * Adding new attributes
 * Modifying existing attributes
@@ -24,15 +23,11 @@ The common use cases for customizing or extending a Shell are:
 * Modifying existing commands
 
 
-## Customizing a shell’s Commands
+## Customizing a shell’s commands
 
 When customizing an official shell you can add new commands, and also modify or hide existing ones.
 
-**To add a new command:**
-
-1)  Add the command in the shell’s driver.py file.
-
-2) Expose the command in the shell’s *drivermetadata.xml* file.
+* **To add a new command:** Add the command in the shell’s driver.py file, and expose the command in the shell’s *drivermetadata.xml* file.
 
 The command’s logic should be placed either in the driver itself or in a separate python package.
 
@@ -46,34 +41,34 @@ It is also possible to hide or remove a command. Hiding a command is done by pla
 
 When adding or modifying a command, you can leverage Quali’s shell framework to ease the development process, see more information [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
-See some common examples for shell’s command extension in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
+See some common command extension examples in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
 
 
 ## Customizing a shell’s attributes
 
 CloudShell provides two ways to customize attributes:
 
-* **Customizing an existing Shell**: Use this option when the modifications are related to a specific device but are not relevant to other Shells. This is done by manually editing the Shell’s *shell-definition.yaml* file.
-* **Associating custom attributes with a Shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute.
+* **Customizing an existing shell**: Use this option when the modifications are related to a specific device but are not relevant to other shells. This is done by manually editing the shell’s *shell-definition.yaml* file.
+* **Associating custom attributes with a shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple shells. For example, the Execution Server Selector attribute.
 
 The second option of associating custom attributes with an already installed shell is done by calling the [SetCustomShellAttribute]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html#SetCustomShellAttribute) API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html). The first option currently only applies to the root model of the shell, so if you need to customize your shell’s sub-resource models, such as blades and ports, use the second option. Note that CloudShell version 9.0 will support sub-resource attribute modifications via the *shell-definition.yaml* file.
 
-**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original Shell is based on.
+**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original shell is based on.
 
 
-### Adding attributes to a Shell’s model
+### Adding attributes to a shell’s model
 
 The shell’s path can be a URL to the shell template’s zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
 
-**To add attributes to a Shell’s root model:**
+**To add attributes to a shell’s root model:**
 
 1)  Open command-line.
 
-2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template’s root folder.
+2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original shell template’s root folder.
 
 3) Run the following in command-line:
 
-{% highlight bash %}shellfoundy extend <URL/path-to-Shell-template>{% endhighlight %}
+{% highlight bash %}shellfoundy extend <URL/path-to-shell-template>{% endhighlight %}
 
 4) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
@@ -139,7 +134,7 @@ properties:
 {% endhighlight %}
 
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the Modeling Shells with TOSCA.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).
 
 4) Replace `<property_name>` with the attribute’s name. Do not remove the colon (:) from the end of the line.
 

--- a/_shells/8.1.0/customizing-shells.md
+++ b/_shells/8.1.0/customizing-shells.md
@@ -19,7 +19,7 @@ Customizing an existing Shell is done using the `shellfoundry extend` command. T
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+To learn how to add and customize commands, see [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
 CloudShell provides two ways to customize attributes:
 * Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 

--- a/_shells/8.1.0/deploying-to-production.md
+++ b/_shells/8.1.0/deploying-to-production.md
@@ -30,7 +30,7 @@ This will create two artifacts in the 'dist' sub-folder of the Shell project:
 1. A zip file archive called _\<shellname\>.zip_ - This is the Shell distributable package
 2. A folder named _offline_requirements_ - The Python packages required by the Shell. This folder should be used with any offline execution servers, i.e. execution servers where pip will not be able to reach the internet to download the packages specified in requirements.txt
 
-### Adding custom attributes to the Shell
+### Adding custom attributes to the Shell<a name="SetCustomShellAttribute"></a>
 
 Using the API, you can add attributes to your Shell and customize their defaults for this Shell. This is done using the `SetCustomShellAttribute` API method, available in the TestShell XML RPC and Python APIs. 
 

--- a/_shells/8.1.0/driver-deep-dive.md
+++ b/_shells/8.1.0/driver-deep-dive.md
@@ -160,7 +160,7 @@ Re-install the shell. You'll now see the commands pane has a regular stop button
 stop button the _is_cancelled_ property on the _cancellation_context_ object will be updated and the driver will get a chance to
 complete its current actions and end its execution.
 
-#### Drivers and concurrency
+#### Drivers and concurrency<a name="drivers-and-concurrency"></a>
 
 CloudShell supports two modes for drivers:
 

--- a/_shells/8.1.0/getting-started.md
+++ b/_shells/8.1.0/getting-started.md
@@ -13,7 +13,7 @@ version:
 
 In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to creating Shell resources and running commands in CloudShell.
 
-_**Before developing shells, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing shells, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### What is a shell?
 

--- a/_shells/8.1.0/getting-started.md
+++ b/_shells/8.1.0/getting-started.md
@@ -11,16 +11,36 @@ version:
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to instancing Shell resources and running commands in CloudShell.
+In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to creating Shell resources and running commands in CloudShell.
 
 _**Before developing shells, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+
+### What is a shell?
+
+A Shell enables CloudShell users to interact with different sandbox elements, like physical devices and virtual appliances. A Shell models the sandbox element in CloudShell and provides commands that CloudShell users and automation processes can run on it, like Power On and Health Check.
+
+In our [community](http://community.quali.com/spaces/12/index.html?__hstc=46213176.aaafbe5adb338215377a985e0c025079.1467146361756.1471392182746.1471395614692.11&__hssc=46213176.1.1471395614692&__hsfp=2437115919), you can find both officially released shells and shells developed in our developer community. If you find a shell that fits your needs, you’re welcome to use it as is, or, you can customize its settings and automation, as explained in [Customizing Shells]({{site.baseurl}}/shells/{{pageVersion}}/customizing-shells.html). If you can’t find the shell you’re looking for, you’re welcome to create a new one from scratch using one of our shell standard templates and contribute it to the community for others to use it as well.
+
+Historically, we have had two types of shells in CloudShell, 1st Generation shells and 2nd Generation shells. While 1st Gen shells are still used, all new shells are released only as 2nd Generation shells and this developer guide focuses on this type of shells. For additional information, see CloudShell Help's [Shells Overview](http://help.quali.com/Online%20Help/8.1.0.4496/Portal/Content/CSP/LAB-MNG/Shells.htm).
+
+The basic shell creation process is as follows:
+
+1)  Install shellfoundry, our command-line utility for creating and managing the shell development process
+
+2)  Create or customize a shell. 
+
+3)  Upload the shell to CloudShell.
+
+4)  If the shell requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See CloudShell help's help's [Updating Python Dependencies for Shells, Drivers and Scripts](http://help.quali.com/Online%20Help/8.1.0.4496/Portal/Content/Admn/Updt-Pyth-Libs.htm).
+
+5)  Create resources in the appropriate domains.
 
 ### Supported versions - CloudShell v.8.0 and up
 As of version 8.0, CloudShell supports 2nd Gen Shells. This guide includes instructions on developing **2nd Gen Shells only**.
 
 For information on developing 1st Gen Shells, see [CloudShell Developer Guide](https://qualisystems.github.io/devguide_7/) CloudShell v7.1 and below.
 
-To learn more about the  different versions of the Shells used by CloudShell and how to upgrade a 1st Gen Shell, see [Converting 1st Generation Shells]({{site.baseurl}}/reference/{{pageVersion}}/migrating_1st_gen_shells.html)
+To learn more about the  different versions of the Shells used by CloudShell and how to upgrade a 1st Gen Shell, see [Converting 1st Generation Shells]({{site.baseurl}}/reference/{{pageVersion}}/migrating_1st_gen_shells.html).
 
 
 

--- a/_shells/8.1.0/modeling-the-shell.md
+++ b/_shells/8.1.0/modeling-the-shell.md
@@ -291,25 +291,7 @@ artifacts:
 
 
 
-#### Add Shell Capabilities
-The Shell’s standard already defines basic capabilities that can be implemented in the Shell. For example, support for SNMP, console connections, device backup and Auto-discovery. The capabilities that are relevant for the Shell are already defined in the Shell’s standard.
-In the _capabilities_ section, we can add additional capabilities or edit the standard capabilities.
+#### Optional Shell Capabilities
+The Shell supports two capabilities that can be enabled, assuming the Shell's driver supports them: auto discovery and concurrent execution of commands.
 
-
-{% highlight yaml %}
-capabilities:
-  auto_discovery_capability:
-    type: cloudshell.capabilities.AutoDiscovery
-    properties:        
-      enable_auto_discovery:
-        type: boolean
-        default: true
-      auto_discovery_description:
-        type: string
-        default: Describe the auto discovery
-      inventory_description:
-        type: string
-        default: Describe the resource shell template
-{% endhighlight %}
-
-The most common use case is customizing the Auto-discovery process. This is covered in detail in [Auto Discovery For Inventory Shells]({{site.baseurl}}/shells/{{pageVersion}}/implementing-discovery-for-inventory-shells.html)
+The implementation of these capabilities is covered in detail in [Auto Discovery For Inventory Shells]({{site.baseurl}}/shells/{{pageVersion}}/implementing-discovery-for-inventory-shells.html) and the Driver Deep Dive article's [Drivers and concurrency]({{site.baseurl}}/shells/{{pageVersion}}/driver-deep-dive.html#drivers-and-concurrency) section.

--- a/_shells/8.2.0/common-driver-recipes.md
+++ b/_shells/8.2.0/common-driver-recipes.md
@@ -74,7 +74,7 @@ We can easily modify the previous code to do that instead:
 {% github_sample QualiSystems/devguide_examples/blob/master/common_driver_recipes/src/driver.py 57 70 %}
 {% endhighlight %}
 
-#### Sending commands to a networking device?
+#### Sending commands to a networking device
 When adding a new command that requires communication with a networking device, such as a switch or router, you need to open a session to the device. An easy way to do that is by leveraging Quali’s shell framework (*cloudshell-cli* package). The framework can provide a session from a session pool via Telnet, SSH or TCP, based on the configuration saved in the **CLI Connection Type** attribute on the root resource.
 
 See the code below for an example:

--- a/_shells/8.2.0/common-driver-recipes.md
+++ b/_shells/8.2.0/common-driver-recipes.md
@@ -73,3 +73,9 @@ We can easily modify the previous code to do that instead:
 {% highlight python %}
 {% github_sample QualiSystems/devguide_examples/blob/master/common_driver_recipes/src/driver.py 57 70 %}
 {% endhighlight %}
+
+#### Sending commands to a networking device?
+When adding a new command that requires communication with a networking device, such as a switch or router, you need to open a session to the device. An easy way to do that is by leveraging Quali’s shell framework (*cloudshell-cli* package). The framework can provide a session from a session pool via Telnet, SSH or TCP, based on the configuration saved in the **CLI Connection Type** attribute on the root resource.
+
+See the code below for an example:
+[TBD code snippet]

--- a/_shells/8.2.0/customizing-driver-commands.md
+++ b/_shells/8.2.0/customizing-driver-commands.md
@@ -21,7 +21,7 @@ In this section we'll explore the different ways in which these commands can be 
 * [Optional parameters and default values](#customizing_optional_parameters)
 * [Restricting input to a specific set of possible values](#customizing_lookup_values)
 * [Adding categories](#customizing_categories)
-* [Orchestration only commands](#customizing_orchestration_only_commands)
+* [Orchestration only commands (hidden commands)](#customizing_orchestration_only_commands)
 
 If you haven't done some already it is recommended to go through the [Getting Started]({{site.baseurl}}/shells/{{pageVersion}}/getting-started.html) tutorial before continuing to get a better understanding of the overall process of creating and using a shell. We also assume you've gone through the steps described in the [Setting Up the Development IDE]({{site.baseurl}}/introduction/{{pageVersion}}/setting-up-the-development-ide.html) section of this guide.
 
@@ -225,10 +225,10 @@ After re-installing the shell we get the following command panel layout:
 
 <a name="customizing_orchestration_only_commands"></a>
 
-### Orchestration only commands
+### Orchestration only commands (hidden commands)
 
-Sometimes, you may wish to create commands that are intended to be used as a part of an orchestration flow, for example to be called during setup, but that you don't wish users to get direct access to or to be visible via the UI. For example, a command that will be called during a sandbox’s Setup process.
-To support this use case, CloudShell supports a special category, the _Hidden Commands_ category which allows you to mark commands you want to be omitted from the web portal UI but that can still be invoked via the API.
+Sometimes, you may wish to create commands that are intended to be used as a part of an orchestration flow, for example to be called during setup, but want these commands to be inaccessible to users [hidden] from the UI. For example, a command that is called during a sandbox’s Setup process.
+To support this use case, CloudShell supports a special category, the _Hidden Commands_ category, which allows you to omit commands from the web portal UI while allowing them to be invoked via the API.
 
 To demonstrate this capability, let's first add a new function to our driver class in the _driver.py_ file:
 

--- a/_shells/8.2.0/customizing-shells.md
+++ b/_shells/8.2.0/customizing-shells.md
@@ -8,15 +8,14 @@ version:
     - 8.2.0
 ---
 
-
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
 In this section, we’ll learn how to create and modify a shell’s commands and attributes.
 
-Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell’s Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. 
+Customizing an existing shell is done using the `shellfoundry extend` command. This command downloads the source code of the shell you wish to customize to your local machine and updates the shell’s Author. Note that extending official shells (shells that were released by Quali) will remove their official tag. 
 
-The common use cases for customizing or extending a Shell are:
+The common use cases for customizing or extending a shell are:
 
 * Adding new attributes
 * Modifying existing attributes
@@ -24,15 +23,11 @@ The common use cases for customizing or extending a Shell are:
 * Modifying existing commands
 
 
-## Customizing a shell’s Commands
+## Customizing a shell’s commands
 
 When customizing an official shell you can add new commands, and also modify or hide existing ones.
 
-**To add a new command:**
-
-1)  Add the command in the shell’s driver.py file.
-
-2) Expose the command in the shell’s *drivermetadata.xml* file.
+* **To add a new command:** Add the command in the shell’s driver.py file, and expose the command in the shell’s *drivermetadata.xml* file.
 
 The command’s logic should be placed either in the driver itself or in a separate python package.
 
@@ -46,34 +41,34 @@ It is also possible to hide or remove a command. Hiding a command is done by pla
 
 When adding or modifying a command, you can leverage Quali’s shell framework to ease the development process, see more information [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
-See some common examples for shell’s command extension in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
+See some common command extension examples in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
 
 
 ## Customizing a shell’s attributes
 
 CloudShell provides two ways to customize attributes:
 
-* **Customizing an existing Shell**: Use this option when the modifications are related to a specific device but are not relevant to other Shells. This is done by manually editing the Shell’s *shell-definition.yaml* file.
-* **Associating custom attributes with a Shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute.
+* **Customizing an existing shell**: Use this option when the modifications are related to a specific device but are not relevant to other shells. This is done by manually editing the shell’s *shell-definition.yaml* file.
+* **Associating custom attributes with a shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple shells. For example, the Execution Server Selector attribute.
 
 The second option of associating custom attributes with an already installed shell is done by calling the [SetCustomShellAttribute]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html#SetCustomShellAttribute) API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html). The first option currently only applies to the root model of the shell, so if you need to customize your shell’s sub-resource models, such as blades and ports, use the second option. Note that CloudShell version 9.0 will support sub-resource attribute modifications via the *shell-definition.yaml* file.
 
-**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original Shell is based on.
+**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original shell is based on.
 
 
-### Adding attributes to a Shell’s model
+### Adding attributes to a shell’s model
 
 The shell’s path can be a URL to the shell template’s zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
 
-**To add attributes to a Shell’s root model:**
+**To add attributes to a shell’s root model:**
 
 1)  Open command-line.
 
-2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template’s root folder.
+2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original shell template’s root folder.
 
 3) Run the following in command-line:
 
-{% highlight bash %}shellfoundy extend <URL/path-to-Shell-template>{% endhighlight %}
+{% highlight bash %}shellfoundy extend <URL/path-to-shell-template>{% endhighlight %}
 
 4) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
@@ -139,7 +134,7 @@ properties:
 {% endhighlight %}
 
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the Modeling Shells with TOSCA.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).
 
 4) Replace `<property_name>` with the attribute’s name. Do not remove the colon (:) from the end of the line.
 

--- a/_shells/8.2.0/customizing-shells.md
+++ b/_shells/8.2.0/customizing-shells.md
@@ -19,7 +19,7 @@ Customizing an existing Shell is done using the `shellfoundry extend` command. T
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/shells/{{pageVersion}}/customizing-shell-commands.html).
+To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
 CloudShell provides two ways to customize attributes:
 * Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 

--- a/_shells/8.2.0/customizing-shells.md
+++ b/_shells/8.2.0/customizing-shells.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Customizing a 2nd Gen Shell's Attributes
+title: Customizing Shells
 category: tut
 order: 13
 comments: true
@@ -8,56 +8,82 @@ version:
     - 8.2.0
 ---
 
+
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this section, we’ll learn how to configure and modify attributes in a Shell.
+In this section, we’ll learn how to create and modify a shell’s commands and attributes.
 
-Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell's Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. The common use cases for customizing or extending a Shell are:
+Customizing an existing Shell is done using the `shellfoundry extend` command. This command downloads the source code of the Shell you wish to customize to your local machine and updates the Shell’s Author. Note that extending official Shells (Shells that were released by Quali) will remove their official tag. 
+
+The common use cases for customizing or extending a Shell are:
+
 * Adding new attributes
 * Modifying existing attributes
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+
+## Customizing a shell’s Commands
+
+When customizing an official shell you can add new commands, and also modify or hide existing ones.
+
+**To add a new command:**
+
+1)  Add the command in the shell’s driver.py file.
+
+2) Expose the command in the shell’s *drivermetadata.xml* file.
+
+The command’s logic should be placed either in the driver itself or in a separate python package.
+
+Modifications to a command can include adding some logic either before or after the command or changing the command logic itself. In order to do that, **copy the command code** from the original Quali python package to the shell driver or to the custom python package you created (*the command logic resides either in the vendor package or vendor-os package - for example in “cloudshell-cisco” or “cloudshell-cisco-ios”*).
+
+When modifying an existing command, you can add optional input parameters. Just make sure that the implementation is backwards compatible. Note that adding mandatory inputs or removing one of the original inputs is not supported. In these cases, it is recommended to create an additional command with a different name, instead of modifying an existing one.
+
+[TBD – code example]
+
+It is also possible to hide or remove a command. Hiding a command is done by placing it in an “administrative” [category]({{site.baseurl}}/shells/{{pageVersion}}/customizing-driver-commands.html) in the drivermetadata.xml. Note that removing a command might affect how the shell is used since CloudShell and/or some orchestration scripts might depend on the existing driver’s commands.
+
+When adding or modifying a command, you can leverage Quali’s shell framework to ease the development process, see more information [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+
+See some common examples for shell’s command extension in [Common Driver Recipes]({{site.baseurl}}/shells/{{pageVersion}}/common-driver-recipes.html).
+
+
+## Customizing a shell’s attributes
 
 CloudShell provides two ways to customize attributes:
-* Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 
-This is done by manually editing the Shell’s **shell-definition.yaml** file.
-* Associating custom attributes with a Shell that is installed in CloudShell: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute. 
 
-The second option of associating custom attributes with an already installed shell is done by calling the `SetCustomShellAttribute` API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html).
-The first option currently only applies to the root model of the Shell, so if you need to customize your Shell’s sub-resource models, such as blades and ports, use the second option. Note that version 9.0 will support sub-resource attribute modifications via the **shell-definition.yaml** file.
+* **Customizing an existing Shell**: Use this option when the modifications are related to a specific device but are not relevant to other Shells. This is done by manually editing the Shell’s *shell-definition.yaml* file.
+* **Associating custom attributes with a Shell that is installed in CloudShell**: Use this option when the additional attributes are deployment-related and required in multiple Shells. For example, the Execution Server Selector attribute.
 
-Note that deleting a 2nd Gen Shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen Shell's data model (families and models) and its structure, which is as defined in the relevant Shell standard the original Shell is based on.
+The second option of associating custom attributes with an already installed shell is done by calling the [SetCustomShellAttribute]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html#SetCustomShellAttribute) API method. For additional information on this method, see [Deploying to Production]({{site.baseurl}}/shells/{{pageVersion}}/deploying-to-production.html). The first option currently only applies to the root model of the shell, so if you need to customize your shell’s sub-resource models, such as blades and ports, use the second option. Note that CloudShell version 9.0 will support sub-resource attribute modifications via the *shell-definition.yaml* file.
 
+**Important:** Deleting a 2nd Gen shell’s default attributes is not supported. It is also not possible to customize a 2nd Gen shell’s data model (families and models) and its structure, which is as defined in the shell standard the original Shell is based on.
 
 
-### Adding attributes to a Shell's model
+### Adding attributes to a Shell’s model
 
-The Shell's path can be a URL to the Shell template's zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the Shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
+The shell’s path can be a URL to the shell template’s zip file on GitHub or the filesystem path (prefixed by `local:./`) to the root folder of the shell. For additional information and examples, see [Shellfoundry]({{site.baseurl}}/reference/{{pageVersion}}/shellfoundry-intro.html).
 
 **To add attributes to a Shell’s root model:**
 
-1) Open command-line.
+1)  Open command-line.
 
-2) To extend a Shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template's root folder.
+2) To customize a shell that resides on your local machine, make sure command-line is pointing to a different path from the original Shell template’s root folder.
 
 3) Run the following in command-line:
 
-{% highlight bash %}
-shellfoundy extend <URL/path-to-Shell-template>
-{% endhighlight %}
+{% highlight bash %}shellfoundy extend <URL/path-to-Shell-template>{% endhighlight %}
 
-4) In the Shell’s download folder, open the _shell-definition.yaml_ file in your preferred editor.
+4) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
 5) Locate `node-types:`.
 
 6) Under the root level model, add the following lines:
 
 {% highlight bash %}
-    properties:
-     property_name:
+properties:
+     <property_name>:
        type: string
        default: fast
        description: Some attribute description
@@ -65,48 +91,45 @@ shellfoundy extend <URL/path-to-Shell-template>
          - valid_values: [fast, slow]
        tags: [configuration, setting, not_searchable, abstract_filter, include_in_insight, readonly_to_users display_in_diagram, connection_attribute, read_only]
 {% endhighlight %}
-  
-7) Edit their settings, as appropriate. For  additional information on these settings, see the CloudShell online help.
+
+7) Edit their settings, as appropriate. For additional information on these settings, see the CloudShell online help.
 
 |  Properties        |  Description 
 |  :----------------   | :----------------------------------------------------------------- |            
-|  property_name     |  Attribute's name                        |
-|  type            |   Type of attribute. Optional values: string, integer, float, boolean, cloudshell.datatypes.Password  |
-|  default       |  Default value.                           |
-|  description          |  Attribute's description                                   |
-|  constraints              |  Permitted values       |
-|  tags              |  Attribute rules. For details, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).            |
+|  `<property_name>`     |  Replace `<property_name>` with the new attribute’s display name. Do not remove the colon (:) from the end of the line.            |
+|  `type`            |   Type of attribute. Optional values: string, integer, float, boolean, cloudshell.datatypes.Password  |
+|  `default`       |  Default value.                           |
+|  `description`          |  Attribute's description                                   |
+|  `constraints`              |  Permitted values       |
+|  `tags`              |  Attribute rules. For details, see [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).            |
 
 8) Remove any unneeded lines.
 
 9) Save the file.
 
-10) In command-line, navigate to the Shell’s root folder.
+10) In command-line, navigate to the shell’s root folder.
 
-11) Package the Shell.
+11) Package the shell.
 
 {% highlight bash %}shellfoundry pack{% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the Shell to CloudShell:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the shell to CloudShell:
 
 {% highlight bash %}shellfoundry install{% endhighlight %}
-
-
-
 
 ### Modifying an existing attribute
 
 **To modify an attribute’s rules:**
 
-1) Download the Shell template, as explained in the above section.
+1) Download the shell template, as explained in the above section.
 
-2) In the Shell’s download folder, open the **shell-definition.yaml** file in your preferred editor.
+2) In the shell’s download folder, open the *shell-definition.yaml* file in your preferred editor.
 
 3) Under `node-types:`, add the following lines.
 
 {% highlight bash %}
-    properties:
-     property_name:
+properties:
+     <property_name>:
        type: string
        default: fast
        description: Some attribute description
@@ -115,22 +138,23 @@ shellfoundy extend <URL/path-to-Shell-template>
        tags: [configuration, setting, not_searchable, abstract_filter, include_in_insight, readonly_to_users display_in_diagram, connection_attribute, read_only]
 {% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the [Modeling Shells with TOSCA]({{site.baseurl}}/shells/{{pageVersion}}/modeling-the-shell.html).
 
-4) Replace `property_name` with the attribute’s name. Do not remove the colon (`:`} from the end of the line.
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;For details about the tags, see the Modeling Shells with TOSCA.
 
-5) Edit the attribute's settings. 
+4) Replace `<property_name>` with the attribute’s name. Do not remove the colon (:) from the end of the line.
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Note:** You cannot modify attributes **type**, **name**, and any attributes that are associated with the Shell's family as this will affect other Shells that use this family.
+5) Edit the attribute’s settings.
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;**Note:** You cannot modify attributes **type**, **name**, and any attributes that are associated with the shell’s family as this will affect other shells that use this family.
 
 6) Save the file.
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;The attribute is updated.
 
-7) In command-line, navigate to the Shell's folder and package the Shell.
+7) In command-line, navigate to the shell’s folder and package the shell.
 
 {% highlight bash %}shellfoundry pack{% endhighlight %}
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the Shell to CloudShell:
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Alternatively, package and import the shell to CloudShell:
 
 {% highlight bash %}shellfoundry install{% endhighlight %}

--- a/_shells/8.2.0/customizing-shells.md
+++ b/_shells/8.2.0/customizing-shells.md
@@ -19,7 +19,7 @@ Customizing an existing Shell is done using the `shellfoundry extend` command. T
 * Adding new commands
 * Modifying existing commands
 
-To learn how to add and customize commands, see [Customizing a Shell's Commands]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
+To learn how to add and customize commands, see [Quali's Shell Framework]({{site.baseurl}}/reference/{{pageVersion}}/quali-shell-framework.html).
 
 CloudShell provides two ways to customize attributes:
 * Customizing an existing Shell: Use this option when the modifications are related to a specific device but are not relevant to other Shells. 

--- a/_shells/8.2.0/deploying-to-production.md
+++ b/_shells/8.2.0/deploying-to-production.md
@@ -30,7 +30,7 @@ This will create two artifacts in the 'dist' sub-folder of the Shell project:
 1. A zip file archive called _\<shellname\>.zip_ - This is the Shell distributable package
 2. A folder named _offline_requirements_ - The Python packages required by the Shell. This folder should be used with any offline execution servers, i.e. execution servers where pip will not be able to reach the internet to download the packages specified in requirements.txt
 
-### Adding custom attributes to the Shell
+### Adding custom attributes to the Shell<a name="SetCustomShellAttribute"></a>
 
 Using the API, you can add attributes to your Shell and customize their defaults for this Shell. This is done using the `SetCustomShellAttribute` API method, available in the TestShell XML RPC and Python APIs. 
 

--- a/_shells/8.2.0/driver-deep-dive.md
+++ b/_shells/8.2.0/driver-deep-dive.md
@@ -160,7 +160,7 @@ Re-install the shell. You'll now see the commands pane has a regular stop button
 stop button the _is_cancelled_ property on the _cancellation_context_ object will be updated and the driver will get a chance to
 complete its current actions and end its execution.
 
-#### Drivers and concurrency
+#### Drivers and concurrency<a name="drivers-and-concurrency"></a>
 
 CloudShell supports two modes for drivers:
 

--- a/_shells/8.2.0/getting-started.md
+++ b/_shells/8.2.0/getting-started.md
@@ -11,16 +11,36 @@ version:
 {% assign pageUrlSplited = page.url | split: "/" %}
 {% assign pageVersion = pageUrlSplited[2] %}
 
-In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to instancing Shell resources and running commands in CloudShell.
+In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to creating Shell resources and running commands in CloudShell.
 
 _**Before developing shells, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+
+### What is a shell?
+
+A Shell enables CloudShell users to interact with different sandbox elements, like physical devices and virtual appliances. A Shell models the sandbox element in CloudShell and provides commands that CloudShell users and automation processes can run on it, like Power On and Health Check.
+
+In our [community](http://community.quali.com/spaces/12/index.html?__hstc=46213176.aaafbe5adb338215377a985e0c025079.1467146361756.1471392182746.1471395614692.11&__hssc=46213176.1.1471395614692&__hsfp=2437115919), you can find both officially released shells and shells developed in our developer community. If you find a shell that fits your needs, you’re welcome to use it as is, or, you can customize its settings and automation, as explained in [Customizing Shells]({{site.baseurl}}/shells/{{pageVersion}}/customizing-shells.html). If you can’t find the shell you’re looking for, you’re welcome to create a new one from scratch using one of our shell standard templates and contribute it to the community for others to use it as well.
+
+Historically, we have had two types of shells in CloudShell, 1st Generation shells and 2nd Generation shells. While 1st Gen shells are still used, all new shells are released only as 2nd Generation shells and this developer guide focuses on this type of shells. For additional information, see CloudShell Help's [Shells Overview](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/CSP/LAB-MNG/Shells.htm).
+
+The basic shell creation process is as follows:
+
+1)  Install shellfoundry, our command-line utility for creating and managing the shell development process
+
+2)  Create or customize a shell. 
+
+3)  Upload the shell to CloudShell.
+
+4)  If the shell requires the use of python dependencies, which aren’t available in the public PyPi repository, add them to the local PyPi Server. See CloudShell help's help's [Updating Python Dependencies for Shells, Drivers and Scripts](http://help.quali.com/Online%20Help/8.2.0.3019/Portal/Content/Admn/Updt-Pyth-Libs.htm).
+
+5)  Create resources in the appropriate domains.
 
 ### Supported versions - CloudShell v.8.0 and up
 As of version 8.0, CloudShell supports 2nd Gen Shells. This guide includes instructions on developing **2nd Gen Shells only**.
 
 For information on developing 1st Gen Shells, see [CloudShell Developer Guide](https://qualisystems.github.io/devguide_7/) CloudShell v7.1 and below.
 
-To learn more about the  different versions of the Shells used by CloudShell and how to upgrade a 1st Gen Shell, see [Converting 1st Generation Shells]({{site.baseurl}}/reference/{{pageVersion}}/migrating_1st_gen_shells.html)
+To learn more about the  different versions of the Shells used by CloudShell and how to upgrade a 1st Gen Shell, see [Converting 1st Generation Shells]({{site.baseurl}}/reference/{{pageVersion}}/migrating_1st_gen_shells.html).
 
 
 

--- a/_shells/8.2.0/getting-started.md
+++ b/_shells/8.2.0/getting-started.md
@@ -13,7 +13,7 @@ version:
 
 In this section, we’ll go through the basic steps of creating a new Shell. The goal is to demonstrate the end-to-end cycle, from generating a new Shell project to creating Shell resources and running commands in CloudShell.
 
-_**Before developing shells, please familiarize yourself with CloudShell by taking a course in [Quali University](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
+_**Before developing shells, please familiarize yourself with CloudShell by taking [Quali U courses](http://university.quali.com). These courses also include installation instructions for the CloudShell SDK package that deploys a developer edition of CloudShell on which you can perform your training and development activities.**_
 
 ### What is a shell?
 

--- a/_shells/8.2.0/modeling-the-shell.md
+++ b/_shells/8.2.0/modeling-the-shell.md
@@ -292,25 +292,7 @@ artifacts:
 
 
 
-#### Add Shell Capabilities
-The Shell’s standard already defines basic capabilities that can be implemented in the Shell. For example, support for SNMP, console connections, device backup and Auto-discovery. The capabilities that are relevant for the Shell are already defined in the Shell’s standard.
-In the _capabilities_ section, we can add additional capabilities or edit the standard capabilities.
+#### Optional Shell Capabilities
+The Shell supports two capabilities that can be enabled, assuming the Shell's driver supports them: auto discovery and concurrent execution of commands.
 
-
-{% highlight yaml %}
-capabilities:
-  auto_discovery_capability:
-    type: cloudshell.capabilities.AutoDiscovery
-    properties:        
-      enable_auto_discovery:
-        type: boolean
-        default: true
-      auto_discovery_description:
-        type: string
-        default: Describe the auto discovery
-      inventory_description:
-        type: string
-        default: Describe the resource shell template
-{% endhighlight %}
-
-The most common use case is customizing the Auto-discovery process. This is covered in detail in [Auto Discovery For Inventory Shells]({{site.baseurl}}/shells/{{pageVersion}}/implementing-discovery-for-inventory-shells.html)
+The implementation of these capabilities is covered in detail in [Auto Discovery For Inventory Shells]({{site.baseurl}}/shells/{{pageVersion}}/implementing-discovery-for-inventory-shells.html) and the Driver Deep Dive article's [Drivers and concurrency]({{site.baseurl}}/shells/{{pageVersion}}/driver-deep-dive.html#drivers-and-concurrency) section.


### PR DESCRIPTION
IN PROGRESS, DO NOT MERGE

Retitled from Customizing a 2nd Gen Shell's Commands to Quali's Shell Framework
moved from Shells collection to Reference collection
Updated overview and Introduction per Alona/Gal
fixed display order of the 1st Gen shell migration and service categories articles to accomodate the new article

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/devguide_source/101)
<!-- Reviewable:end -->
